### PR TITLE
Prefer PRs to comments

### DIFF
--- a/jep/1/README.adoc
+++ b/jep/1/README.adoc
@@ -385,6 +385,24 @@ Strategies to keep the discussion efficient include:
 
 JEP sponsors should use their discretion here.
 
+////
+We found that the Github UI bogs down around 150-200 comments.
+I'd like people feedback on a potential solution.
+
+I'm completely solid on the details yet,
+but the idea is to RECOMMMEND that users propose changes via PRs
+from their own forks rather than by commenting on the base PR.
+
+1. Fork the `jenkinsci/jep` repository
+2. Make proposed changes in a branch on that fork
+3. Submit a PR to the JEP feature branch.
+4. If a PR from the feature branch to master is open, reference that PR in the personal PR.
+      Examnple : "Typo fixes to #12".
+
+For feedback, questions, or less solid ideas, add them as asciidoc comments below/near the lines you'd like to discuss.
+Then people can respond in that PR.
+////
+
 The JEP sponsor may also ask JEP editors for further feedback regarding the
 style and consistency of a JEP and its readiness for review by the BDFL.
 


### PR DESCRIPTION
This is an example of the idea I'd like to try.  As noted in #12, and in the comments below I'd like to recommend (or at least describe) in JEP-1 how changes to a JEP can be suggested, refined, and merged to a JEP Draft. 

The intent of this idea was motivated by the limitations of the Github PR UI, but I'm wondering if it might have other benefits.  
* Quicker turn-around - If people spot more than a few typos, submitting a PR to fix all of them is about the same amount of effort for the reviewer as making the comments and is much easier for the sponsor or other contributors. 
* Focus on outcomes - Comments seem guide people toward asking if something can be done rather than doing it.  As with typos, talking about doing something often takes more effort than writing something concrete, submitting it as a PR, and doing a couple iterations on that PR. 
* Alternate views easy to add to "Reasoning" - I ended up adding several topic to the Reasoning section based on comments.  If these comments had been in their own PR, it would have been easier for those who proposed the ideas to move them to the Reasoning section for merging, rather than bottlenecking at one contributor making changes.

This is obviously a work in progress.  I'd like feedback before trying to hammer out details.

@jenkinsci/jep-editors @daniel-beck 




