### PR TITLE
Suggesting that the merge to master occur when a JEP is finalized

### DIFF
--- a/jep/1/README.adoc
+++ b/jep/1/README.adoc
@@ -485,6 +485,8 @@ When the implementation is complete and incorporated into the
 appropriate "main" code repository, the JEP sponsor will change
 the JEP's status changed to "Final".
 
+At this time the JEP editors will merge its feature branch into the `master` branch of the `jep` repository.
+
 [[maintenance]]
 ==== JEP Maintenance
 
@@ -840,6 +842,9 @@ Once the JEP is ready for the repository, a JEP editor will:
 . Update the folder number to match the JEP number
 . Update the JEP number in the document.
 
+==== Mark as Final
+
+Once a JEP is finalized, a JEP editor will merge its feature branch into `master` and delete the feature branch.
 
 == Motivation
 


### PR DESCRIPTION
#12 apparently never said if or when a `jep-nnnn` feature branch would be merged into `master`. I am picking finalization time as a first pass, though it might make more sense to put it in `master` as soon as it is accepted.

(Frankly I was a little surprising to find that the merge to `master` does not happen as soon as the _draft_ is accepted. That is after all the point at which you are committed to a particular number, so as a record of this JEP’s existence and status IMO it should be there already, even if it was ultimately rejected or abandoned.)