### PR TITLE
Reset JEP-201 to Draft

### DIFF
--- a/jep/201/README.adoc
+++ b/jep/201/README.adoc
@@ -22,7 +22,7 @@ endif::[]
 | https://github.com/ewelinawilkosz2[Ewelina Wilkosz] from https://github.com/praqma[Praqma]
 
 | Status
-| Accepted :ok_hand:
+| Draft :speech_balloon:
 //| Rejected :no_entry:
 //| Withdrawn :hand:
 //| Final :lock:

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -16,7 +16,7 @@
 | Final :lock:
 | link:200/[JEP-200: Switch Remoting/XStream blacklist to a whitelist]
 
-| Accepted :ok_hand:
+| Draft :speech_balloon:
 | link:201/[JEP-201: Jenkins Configuration as Code]
 
 | Accepted :ok_hand:


### PR DESCRIPTION
Based clarifications in PR #76, this JEP is being
returned to Draft.  This is specifically because
the design and scope of this JEP are still being
worked out.  Support for this JEP remains strong,
implementation is in progress, and we fully expect
this JEP will be accepted once the scope and design
discussions are complete.

@ewelinawilkosz @ndeloof @kohsuke @jenkinsci/jep-editors 