### PR TITLE
Require UTF-8 for simplicity

### DIFF
--- a/jep/304/README.adoc
+++ b/jep/304/README.adoc
@@ -93,6 +93,7 @@ It is left to the consumer to decide how to know where to start from in case of 
 Though it is a subject for another design document, it is suggested to:
 *** store the last timestamp that was read ;
 *** be able to idempotently send everything to the backend (in case of a fresh startup, or a missing value for the last read and sent timestamp), and that already sent logs are deduplicated or ignored there.
+* in _UTF-8_ (The _JSON_ specification allows some other encodings. We restrict it to _UTF-8_ only)
 ** 5 files maximum ;
 ** Approximately 10 MB maximum per file.
 ** This should give largely enough time for the client to parse and send everything before it gets rotated, even more because only logs ≥ `WARNING` will be sent.


### PR DESCRIPTION
JSON allows many possible encoding. We restrict it to UTF-8 only for simplicity.

>[JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32.  The default
   encoding is UTF-8, and JSON texts that are encoded in UTF-8 are
   interoperable in the sense that they will be read successfully by the
   maximum number of implementations; there are many implementations
   that cannot successfully read texts in other encodings (such as
   UTF-16 and UTF-32).](https://tools.ietf.org/html/rfc7159#section-8.1)