### PR TITLE
Assining BDFL delegates to 30x JEPs

### DIFF
--- a/jep/304/README.adoc
+++ b/jep/304/README.adoc
@@ -39,8 +39,8 @@ endif::[]
 //
 //
 // Uncomment if there will be a BDFL delegate for this JEP.
-//| BDFL-Delegate
-//| :bulb: Link to github user page :bulb:
+| BDLF-Delegate
+| https://github.com/rtyler[R. Tyler Croy]
 //
 //
 // Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.

--- a/jep/305/README.adoc
+++ b/jep/305/README.adoc
@@ -35,8 +35,8 @@ endif::[]
 | link:https://issues.jenkins-ci.org/browse/JENKINS-50686[JENKINS-50686]
 
 // Uncomment if there will be a BDFL delegate for this JEP.
-//| BDLF-Delegate
-//| :bulb: Link to github user page :bulb:
+| BDLF-Delegate
+| https://github.com/rtyler[R. Tyler Croy]
 
 | Requires
 | https://github.com/jenkins-infra/iep/blob/master/iep-009/README.adoc[IEP-9]


### PR DESCRIPTION
Assigning BDFL delegate for JEP-30x

For the context of how I select BDFL delegate, please see here:
https://groups.google.com/forum/#!msg/jenkinsci-dev/spDAr8EJm3c/ba-ppaM7BgAJ

As a sponsor of JEP-300, I consider Tyler to be the leader of this
effort, and as such he should be the BDFL delegate of this JEP.
