### PR TITLE
Accept jep6

### DIFF
--- a/jep/6/README.adoc
+++ b/jep/6/README.adoc
@@ -24,9 +24,9 @@ endif::[]
 | link:https://github.com/daniel-beck/[Daniel Beck]
 
 | Status
-| Draft :speech_balloon:
+//| Draft :speech_balloon:
 //| Deferred :hourglass:
-//| Accepted :ok_hand:
+| Accepted :ok_hand:
 //| Rejected :no_entry:
 //| Withdrawn :hand:
 //| Final :lock:
@@ -151,4 +151,4 @@ There are no testing issues related to this proposal.
 
 == References
 
-n/a
+* link:https://groups.google.com/d/topic/jenkinsci-dev/HaYzG1YVuJI/discussion[dev list thread]

--- a/jep/6/README.adoc
+++ b/jep/6/README.adoc
@@ -45,11 +45,6 @@ endif::[]
 //| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-nnnnn[JENKINS-nnnnn] :bulb:
 //
 //
-// Uncomment if there will be a BDFL delegate for this JEP.
-| BDFL-Delegate
-| Undetermined
-//
-//
 // Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.
 //| Discussions-To
 //| :bulb: Link to where discussion and final status announcement will occur :bulb:


### PR DESCRIPTION
Accepting JEP #6 as BDFL.

In retrospect, I feel like this JEP is squarely in the authority of the
security officer, and I should have just assigned @daniel-beck  as BDFL
Delegate. I apologize for any time delay not doing that might have
caused. I expect the future JEPs in this space to have the security
officer at that time as the initial BDFL Delegate.

The discussion I saw in the mailing list was all supportive of this
move, and my hats off for Daniel's continued push to better security
handling in the Jenkins project.
