### PR TITLE
Allow referencing particular threads for the JEP discussion.

### DIFF
--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -62,7 +62,8 @@ If no suitable BDFL-Delegate can be found, that row may be commented out.
 //| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-nnnnn[JENKINS-nnnnn] :bulb:
 //
 //
-// Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.
+// Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list
+// OR if there is a single thread for the discussion and comments.
 //| Discussions-To
 //| :bulb: Link to where discussion and final status announcement will occur :bulb:
 //

--- a/jep/1/README.adoc
+++ b/jep/1/README.adoc
@@ -500,6 +500,8 @@ JEP review and resolution may also occur on a list other than jenkinsci-dev@goog
 In this case, the "Discussions-To" header in the JEP will identify the
 appropriate alternative list where discussion, review and pronouncement on the
 JEP will occur.
+"Discussions-To" may be also used to reference a particular thread with the discussion
+if the JEP sponsor prefers the discussion to happen in a single thread.
 
 [[accepted]]
 ==== Accepting a JEP


### PR DESCRIPTION
It may be useful, especially for the Dev List with hundreds of threads. It is a follow-up to the discussion with @bitwiseman in JEP-4 (or other JEP) where I tried to reference the thread.

@jenkinsci/jep-editors 
