### PR TITLE
JEP-209: Summary table generation script does not support multi-line sponsor cells

### DIFF
--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -40,7 +40,7 @@ If no suitable BDFL-Delegate can be found, that row may be commented out.
 | :bulb: Title :bulb:
 
 | Sponsor
-| :bulb: Link to github user page :bulb:
+| :bulb: Link to github user page (if multiple, comma separated on one line). Example: link:https://github.com/username[User Name], link:https://github.com/username2[User Name 2] :bulb:
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status

--- a/jep/309/README.adoc
+++ b/jep/309/README.adoc
@@ -19,8 +19,7 @@ endif::[]
 | Bill of Materials
 
 | Sponsors
-| link:https://github.com/carlossg[Carlos Sanchez],
-  link:https://github.com/oleg-nenashev[Oleg Nenashev]
+| link:https://github.com/carlossg[Carlos Sanchez], link:https://github.com/oleg-nenashev[Oleg Nenashev]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status


### PR DESCRIPTION
Just fixing the JEP formatting

Before:

<img width="1172" alt="screen shot 2018-08-08 at 15 36 50" src="https://user-images.githubusercontent.com/3000480/43840482-19893932-9b21-11e8-85d0-a68cf0c05faf.png">

