### PR TITLE
[JEP-310] Uncomment the associated JIRA ID

### DIFF
--- a/jep/310/README.adoc
+++ b/jep/310/README.adoc
@@ -37,8 +37,8 @@ endif::[]
 //
 //
 // Uncomment if there is an associated placeholder JIRA issue.
-//| JIRA
-//| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-52210[JENKINS-52210] :bulb:
+| JIRA
+| https://issues.jenkins-ci.org/browse/JENKINS-52210[JENKINS-52210]
 //
 //
 // Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.


### PR DESCRIPTION
I had specified it, but forgotten to remove the `// `

Followup for https://github.com/jenkinsci/jep/pull/140