### PR TITLE
Fixed typos and some stylistic/grammar things

### DIFF
--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -89,22 +89,22 @@ If no suitable BDFL-Delegate can be found, that row may be commented out.
 ====
 Give a short (200 word) description of the technical issue addressed.
 
-* Use present tense - describe what the proposal "does" (as if it were already done) not what it will do.
-* Do not go into technical details, those go in the Specification section.
-* Do not talk about history or why this needs to be done, that is part of Motivation section.
+* Use present tense - describe what the proposal "does" (as if it were already done), not what it will do.
+* Do not go into technical details and instead put those in the Specification section.
+* Do not talk about history or why this needs to be done. Instead, add the history to the Motivation section.
 ====
 
 == Specification
 
 [TIP]
 ====
-Provide a detailed specification what is being proposed.
+Provide a detailed specification of what is being proposed.
 Be as technical and detailed as needed to allow new or existing Jenkins developers
 to reasonably understand the scope/impact of an implementation.
 
-* Use present tense - describe what the proposal "does" (as if it were already done) not what it will do.
-* Do not discuss alternative designs that were rejected, those belong in the Reasoning section.
-* Avoid in-depth discussion or justification of design choices, that belongs in the Reasoning section.
+* Use present tense - describe what the proposal "does" (as if it were already done), not what it will do.
+* Do not discuss alternative designs that were rejected - those belong in the Reasoning section.
+* Avoid in-depth discussion or justification of design choices - that belongs in the Reasoning section.
 ====
 
 == Motivation
@@ -112,9 +112,9 @@ to reasonably understand the scope/impact of an implementation.
 [TIP]
 ====
 Explain why the existing code base or process is inadequate to address the problem that the JEP solves.
-This section may also contain any historal context such as how things were done before this proposal.
+This section may also contain any historical context such as how things were done before this proposal.
 
-* Do not discuss design choices or alternative designs that were rejected, those belong in the Reasoning section.
+* Do not discuss design choices or alternative designs that were rejected - those belong in the Reasoning section.
 ====
 
 == Reasoning
@@ -122,11 +122,11 @@ This section may also contain any historal context such as how things were done 
 [TIP]
 ====
 Explain why particular design decisions were made.
-Describe alternate designs that were considered and related work, e.g. how the feature is supported in other systems.
+Describe alternate designs that were considered and related work. For example, how the feature is supported in other systems.
 Provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
 
 * Use sub-headings to organize this section for ease of readability.
-* Do not talk about history or why this needs to be done, that is part of Motivation section.
+* Do not talk about history or why this needs to be done - that is part of Motivation section.
 ====
 
 == Backwards Compatibility
@@ -146,8 +146,8 @@ There are no backwards compatibility concerns related to this proposal.
 ====
 Describe the security impact of this proposal.
 Outline what was done to identify and evaluate security issues,
-discuss of potential security issues and how they are mitigated or prevented,
-and how the JEP interacts with existing permissions, authentication, authorization, etc.
+discuss potential security issues and how they are mitigated or prevented,
+and detail how the JEP interacts with existing elements in Jenkins, such as permissions, authentication, authorization, etc.
 
 If this proposal will have no impact on security, this section may simply say:
 There are no security risks related to this proposal.
@@ -157,9 +157,9 @@ There are no security risks related to this proposal.
 
 [TIP]
 ====
-Describe any impact on Jenkins project infrastructure.
+Describe any impact on the Jenkins project infrastructure.
 
-Include any additions or changes, interactions with exiting components,
+Include any additions or changes, interactions with existing components,
 potential instabilities, service-level agreements,
 and responsibilities for continuing maintenance.
 Explain the scope of infrastructure changes with sufficient detail
@@ -179,12 +179,12 @@ give a summary of how its correctness (and, if applicable, compatibility, securi
 
 In the preferred case that automated tests can be developed to cover all significant changes, simply give a short summary of the nature of these tests.
 
-If some or all of changes will require human interaction to verify, explain why automated tests are considered impractical.
-Then summarize what kinds of test cases might be required: user scenarios with action steps and expected outcomes.
-Might behavior vary by platform (operating system, servlet container, web browser, etc.)?
+If some or all of the changes will require human interaction to verify them, explain why automated tests are considered impractical.
+Then, summarize what kinds of test cases might be required: user scenarios with action steps and expected outcomes.
+Detail whether behavior might be different based on the platform (operating system, servlet container, web browser, etc.)?
 Are there foreseeable interactions between different permissible versions of components (Jenkins core, plugins, etc.)?
-Are any special tools, proprietary software, or online service accounts required to exercise a related code path (Active Directory server, GitHub login, etc.)?
-When will testing take place relative to merging code changes, and might retesting be required if other changes are made to this area in the future?
+Does this change require that any special tools, proprietary software, or online service accounts to exercise a related code path (e.g., Active Directory server, GitHub login, etc.)?
+When will you complete testing relative to merging code changes, and might retesting be required if other changes are made to this area in the future?
 
 If this proposal requires no testing, this section may simply say:
 There are no testing issues related to this proposal.


### PR DESCRIPTION
I was reviewing the guidance here (which is very good!) to determine how to properly author a Jenkins Enhancement Proposal (JEP). I found a few things that needed a bit of polish. No policy changes - only wording.