### PR TITLE
Draft: Opt-In Continuous Delivery of Jenkins Plugin Releases

### DIFF
--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -115,14 +115,22 @@ community at large.
 
 === Setup
 
-Two main things:
+==== The autorelease Maven profile
 
-A new Maven profile will be created, most likely in the 
+I actually don't know that this is necessary. A new Maven profile can be created, 
+most likely in the 
 link:https://github.com/jenkinsci/plugin-pom[Jenkins plugin parent POM]. 
 
-* enable-autorelease
+==== Changes to `buildPlugin`
 
-A YAML markerfile, stored in the plugin's own repository. Absence of this markerfile will In the following example, we'll use a fictional plugin, called `fancy-branch-source`
+The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, a markerfile, called `Autorelease.yaml`.
+
+==== Autorelease.yaml
+
+A YAML markerfile, stored in the plugin's own repository. Absence of this markerfile will 
+be functionally equivalent to the plugin maintainer opting out of Autorelease. 
+
+In the following example, we'll use a fictional plugin, called `fancy-branch-source`
 
 ```
 plugin: fancy-branch-source
@@ -133,7 +141,7 @@ metadata:
   appendMergeSHA: true
 ```
 
-In the above example, we can see the following:
+In the above example `Autorelease.yaml`, we can see the following:
 
 `plugin: fancy-branch-source`:: 
 This is the name of the plugin, and it matches the repository 
@@ -194,7 +202,7 @@ look like:
         <jenkins.version>2.138.4</jenkins.version>
     </properties>
 
-````
+```
 
 This is all pretty run-of-the-mill stuff for a Jenkins plugin, and is well understood already 
 by Karl and the rest of the plugin maintainer community. To enable autorelease, Karl would 
@@ -211,6 +219,7 @@ metadata:
 
 When Karl merges a commit into the `release-the-fanciness` branch, that merge commit has the 
 SHA `1a2b3c4`. The following takes place:
+
 * A webhook is sent to super-trusted-thing, and a build is performed there. 
 * If the build passes all its tests, a release is generated. In our example, 
 that release number would be `3.1.4-1a2b3c4`, because Karl has chosen to append the merge commit 
@@ -226,47 +235,20 @@ ability to do continuous, merge-driven releases, plugin maintainers can readily 
 Jenkins itself is being worked on in a continuous way. This would be a big win for Jenkins' 
 credibility in an increasingly demanding market space.
 
-[TIP]
-====
-Explain why the existing code base or process is inadequate to address the problem that the JEP solves.
-This section may also contain any historical context such as how things were done before this proposal.
-
-* Do not discuss design choices or alternative designs that were rejected - those belong in the Reasoning section.
-====
-
 == Reasoning
 
-Oh boy the UX for this could really suck. People are going to be overrun with upgrades they think they 
-need to do.
+=== Why Maven?
+With Incrementals having gained fairly wide adoption by plugin maintainers, it seems reasonable to use maven 
 
-Maybe we need an "urgent" flag for those?
 
-[TIP]
-====
-Explain why particular design decisions were made.
-Describe alternate designs that were considered and related work. For example, how the feature is supported in other systems.
-Provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
-
-* Use sub-headings to organize this section for ease of readability.
-* Do not talk about history or why this needs to be done - that is part of Motivation section.
-====
+=== Why a trusted CI system?
+Containment of credentials. By using a single system of record for these builds, a service account, maintained by the JENKINS-CERT team, can be used to access GitHub, deploy to Nexus, and deploy to the update centers.
 
 == Backwards Compatibility
-
-[TIP]
-====
-Describe any incompatibilities and their severity.
-Describe how the JEP proposes to deal with these incompatibilities.
-
-If there are no backwards compatibility concerns, this section may simply say:
-There are no backwards compatibility concerns related to this proposal.
-====
 
 With any plugin upgrade, there are backwards compatibility concerns, and autorelease is no different 
 in that regard. In fact, it could be made worse, because users will get overrun with upgrades. Jenkins 
 existing plugin system only allows for uninstalling one revision. 
-
-
 
 == Security
 
@@ -293,24 +275,19 @@ this in any way.
 
 == Prototype Implementation
 
-[TIP]
-====
-Link to any open source reference implementation of code changes for this proposal.
-The implementation need not be completed before the JEP is
-link:https://github.com/jenkinsci/jep/tree/master/jep/1#accepted[accepted],
-but must be completed before any JEP is given
+As a proof of concept, the (github-branch-source?) plugin will be the first to adopt. This provides 
+the initiative with a heavily used plugin, which sees relatively frequent releases already.
+
+A sample fork of github-branch-source could be provided as a reference implementation for 
+this proposal. It is understood that this need not be completed before this JEP is 
+"link:https://github.com/jenkinsci/jep/tree/master/jep/1#accepted[accepted]", but will need to 
+be made available before this JEP is given 
 "link:https://github.com/jenkinsci/jep/tree/master/jep/1#final[Final]" status.
 
-JEPs which will not include code changes may omit this section.
-====
 
 == References
 
-[TIP]
-====
-Provide links to any related documents.
-This will include links to discussions on the mailing list, pull requests, and meeting notes.
-====
+None yet.
 
 
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -64,21 +64,13 @@ endif::[]
 
 == Abstract
 
-At present, Jenkins plugins are, typically, not released on a continous basis. They 
-are also not released from a single source of truth, such as a trusted Continuous 
-Integration server like link:https://ci.jenkins.io[https://ci.jenkins.io]. 
+This JEP introduces a new system, which enables Jenkins plugin maintainers to add Continuous 
+Delivery to their projects. It is:
 
-The notion of continuous delivery of plugin releases has been discussed previously <<footnote-1,^(1)^>>.
-Considering that Jenkins is a system used to facilitate Continuous Delivery for many users, it makes 
-sense -- and builds credibility -- for the Jenkins developer community to adopt this same practice. 
-
-Having a centralized release system made available to plugin maintainers also provides additional 
-confidence that security best practices are being followed *need footnote without surfacing some 
-awful security problem* 
-
-Continuous celivery from trusted CI is something which plugin maintainers can opt into, but is 
-not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
-versions of their code, they remain free to do so.
+* Opt-in: plugin maintainers can choose to use this
+* Simple to configure: very little needs to be changed in order to enable CD
+* Trusted CI/CD: deployments are produced from a single source of truth, which is managed by 
+the Jenkins project
 
 == Specification
 
@@ -209,11 +201,21 @@ SHA to the end of his autorelease version numbers.
 
 == Motivation
 
-It's no secret that the Jenkins plugin ecosystem is complex. It's also no secret that Jenkins plugins 
-are often developed in a very non-continuous way. This proposal seeks to change this. By offering the 
-ability to do continuous, merge-driven releases, plugin maintainers can readily make the claim that 
-Jenkins itself is being worked on in a continuous way. This would be a big win for Jenkins' 
-credibility in an increasingly demanding market space.
+At present, Jenkins plugins are, typically, not released on a continous basis. They 
+are also not released from a single source of truth, such as a trusted Continuous 
+Integration server like link:https://ci.jenkins.io[https://ci.jenkins.io]. 
+
+The notion of continuous delivery of plugin releases has been discussed previously <<footnote-1,^(1)^>>.
+Considering that Jenkins is a system used to facilitate Continuous Delivery for many users, it makes 
+sense -- and builds credibility -- for the Jenkins developer community to adopt this same practice. 
+
+Having a centralized release system made available to plugin maintainers also provides additional 
+confidence that security best practices are being followed *need footnote without surfacing some 
+awful security problem* 
+
+Continuous celivery from trusted CI is something which plugin maintainers can opt into, but is 
+not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
+versions of their code, they remain free to do so.
 
 == Reasoning
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -93,23 +93,25 @@ ecosystem, Karl settles on link:https://semver.org/[semantic versioning].
 
 4. Add a file to the top directory of his repository called `Autorelease.yaml`. 
 
-5. A webhook is configured on Karl's repository on GitHub to point to `{the-webhook-receiver}`
+5. A webhook is configured on Karl's repository on GitHub to point to a webhook receiver. 
 
 Once ready to create a new release of his plugin, Karl merges some changes to the `master` branch. 
 At which point, the following takes place under the covers: 
 
-1. A webhook is sent to `{the-webhook-receiver}` by GitHub
+1. A webhook is sent to the webhook receier by GitHub
 
-2. The receiver forwards this hook to `${trusted-ci-server}`, which is protected by a VPN
+2. The webhook receiver forwards this hook to a trusted CI server, which is protected by a VPN
 
-3. `${trusted-ci-server}` uses the enhanced version of `buildPlugin` to validate the correctness of 
-Karl's `Autorelease.yaml` file, and the consistency of Karl's chosen version numbering.
+3. The trusted CI server, upon getting the webhook from the trusted receiver, uses the 
+enhanced version of `buildPlugin` to validate the correctness of Karl's `Autorelease.yaml` 
+file, and the consistency of Karl's chosen version numbering.
 
-4. Once `Autorelease.yaml` has been validated, a plugin build is performed on `${trusted-ci-server}` 
-as one would expect.
+4. Once `Autorelease.yaml` has been validated, a plugin build is performed on the trusted CI server.
 
-5. After the build is successful, `${trusted-ci-server}` handles deployment of the built plugin to 
-Artifactory and the Jenkins Update Center.
+5. After the build is successful, the trusted CI server handles deployment of the built plugin to
+Artifactory, at which point 
+link:https://github.com/jenkins-infra/update-center2/blob/master/README.md[the existing UC generator] 
+makes the plugin available on the update center.
 
 === Detailed Setup
 
@@ -121,34 +123,26 @@ be functionally equivalent to the plugin maintainer opting out of Autorelease.
 In the following example, we'll stick with plugin developer Karl, and his fictional 
 plugin `karl-plugin`. Karl's `Autorelease.yaml` file looks like this:
 
-```
-plugin: karl
-kind: plugin
-metadata:
-  autoreleaseEnabled: true
-  triggeringBranch: master
-  versionNumberFields: 3
-```
+[source,yaml]
+----
+kind: plugin <1>
+triggeringBranch: master <2>
+versionNumberFields: 3 <3>
+----
 
-In the above example `Autorelease.yaml`, we can see the following:
-
-`plugin: karl`:: 
-This is the name of the plugin, and it matches the repository 
-name on GitHub.
-`kind`:: 
+<1> `kind`
 The type of project which is being set up for autorelease. In our first iteration of 
 autorelease, this will only be set to `plugin`. The field is here should the Jenkins project 
 want to expand the use of autorelease, such as for building core, or components.
-`metadata`:: 
-Contains the following fields:
-** `autoreleaseEnabled`: A boolean value, indicating whether or not this plugin is participating 
-in autorelease. Allows the maintainer to turn Autorelease on or off, without deleting the file 
-entirely.
-** `triggeringBranch`: Sets the branch which maintainers will merge to in order to trigger 
+
+<2> `triggeringBranch`
+Sets the branch which maintainers will merge to in order to trigger 
 an autorelease webhook. Although this is expected to usually be set to `master`, plugin 
 maintainers can choose a branch name of their preference, e.g., `autorelease`, `release`, 
 etc.
-** `versionNumberFields`: An integer, indicating the number of fields which `buildPlugin` should expect.
+
+<3> `versionNumberFields`
+An integer, indicating the number of fields which `buildPlugin` should expect.
 This is important, because sticking to a consistent numbering scheme makes for easier sorting by version.
 For this example plugin, Karl has set the value to `3`, because he's usuing semantic versioning, e.g., 
 3.1.4.
@@ -312,7 +306,7 @@ We will need a number of things to get this going. The low-level technical detai
 in a separate Infrastructure Enhancement Request, so, this should be considered a summary for now:
 
 1. The webhook, configured on each participating plugin. Security implications of this are a bit beyond the scope of this document so far.
-2. A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
+2. [[webhook-receiver]]A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
 behind a VPN
 3. A trusted Jenkins server for performing builds and deployments. 
 4. `buildPlugin` will need code added to validate `Autorelease.yaml` for correctness, and 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -191,9 +191,7 @@ look like:
 
 No additional changes need to be made to `pom.xml` by Karl, he's good to go.
 
-=== What happens when a release is created
-
-==== Changes to `buildPlugin`
+==== Autorelease.yaml verification in `buildPlugin`
 
 The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, the markerfile, called `Autorelease.yaml`. This 
 markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
@@ -201,20 +199,26 @@ released.
 
 Validation will include:
 
-1. The 
+1. `pluginName` field must match the repository name
+
+2. `versionNumberFields` must match the `revision` property in `pom.xml`. E.g., if `versionNumberFields` is 
+set to `3`, and the `revision` is set to `3.1.4.5`, validation will fail.
+
+3. Validation that no extra fields are present in the file. Comments are allowed, but any unexpected 
+lines will cause validation to fail.
 
 If validation of `Autorelease.yaml` fails for any reason, the build is not performed and nothing gets deployed.
 
+==== Deployment of a successful release
 
-When Karl merges a commit into the `master` branch, that merge commit has the 
+When Karl merges a commit into the `master` branch, that merge commit is commit number 150, and has the 
 SHA `1a2b3c4`. The following takes place:
 
-* A webhook is sent to `${trusted-ci-server}`, and a build is performed there. 
-* If the build passes all its tests, a release is generated. In our example, 
-that release number would be `3.1.4-1a2b3c4`, because Karl has chosen to append the merge commit 
-SHA to the end of his autorelease version numbers.
+* A webhook is sent to `${trusted-ci-server}`, and `Autorelease.yaml` is validated.
+* Once validation passes, a build is performed. If the build passes all its tests, a release 
+is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
 * The built plugin gets deployed to Nexus
-* The resulting plugin appears on the Jenkins Update Center
+* The resulting plugin appears on the Jenkins Update Center, as Fancy Branch Plugin version 3.1.4-150-1a2b3c
 
 == Motivation
 
@@ -236,8 +240,17 @@ versions of their code, they remain free to do so.
 
 == Reasoning
 
-=== Why a trusted CI system?
-Containment of credentials. By using a single system of record for these builds, a service account, maintained by the JENKINS-CERT team, can be used to access GitHub, deploy to Nexus, and deploy to the update centers.
+=== What's with the version numbering?
+
+Jenkins plugin maintainers are already familiar with the way that Incrementals appends a commit 
+number, pluse a merge SHA, to version numbers. These mechanically-generated version numbers offer 
+the ability to predictably sort them, so that external systems, such as the Jenkins update center, 
+can correctly publish the "newest" version. The addition of a merge SHA also allows for at-a-glance 
+feedback to tell people which commits went into the release.
+
+NOTE: This version number management scheme is only one of several possible choices. We expect 
+some lively debate around this topic. But it's very important to ensure that versions can be 
+easily sorted by systems such as the Jenkins update center.
 
 === Why YAML?
 YAML is becoming increasingly common in the Jenkins community, for many reasons. YAML is:
@@ -247,11 +260,18 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 * In use for things like the Kubernetes plugin
 * Easily parsed by any number of publily available libraries
 
+=== Aren't we missing some details about infrastructrue requirements?
+
+In short, yes, we are. This JEP exists to get the conversation started. Once consensus has been reached, 
+a separate Infrastructure Enhancement Proposal (IEP) will be created to go along with this JEP. It would 
+be premature to describe every detail of implementation before consensus is reached.
+
 == Backwards Compatibility
 
 Autorelease introduces no new risks with regard to backwards compatibility of plugins themselves. 
 However, there will be a requirement for plugin maintainers to use a consistent version numbering 
-scheme. Consistent version numbering will prevent problems with sorting versions 
+scheme. Consistent version numbering will prevent problems with sorting versions. This is discussed 
+elsewhere in this document.
 
 With any plugin upgrade, there are backwards compatibility concerns, and Autorelease is no different 
 in that regard. Without Autorelease, there is still nothing stopping a plugin maintainer from releasing 
@@ -262,15 +282,25 @@ maintainers will see no change at all to the way they do their Jenkins plugin wo
 
 == Security
 
-Autorelease should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
+Autorelease can make things more secure
+
+=== Containment of credentials
+
+By using a single system of record for these builds, a service account, maintained by the 
+JENKINS-CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
+the update centers.
+
+=== Automatic enforcement of security best practices
+Autorelease builds will all come from `${trusted-ci-server}`. Rules 
 can be put in place on `${trusted-ci-server}`, which can provide implicit enforcement of the 
-Jenkins infrastructure team's security best practices.
+Jenkins infrastructure team's security best practices. Compliance to these best practices becomes 
+something that plugin maintainers need not worry about.
 
 == Infrastructure Requirements
 
 We will need:
 
-1. The webhook. Security implications of this are a bit beyond the scope of this document so far.
+1. The webhook, configured on each participating plugin . Security implications of this are a bit beyond the scope of this document so far.
 ALSO a receiver for the webhook. This 
 2. A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
 behind a VPN

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -205,7 +205,7 @@ will fail.
 3. Validation that no extra fields are present in the file. Comments are allowed, but any unexpected 
 lines will cause validation to fail.
 
-If validation of `Autorelease.yaml` fails for any reason, the build is not performed nothing gets deployed, 
+If validation of `Autorelease.yaml` fails for any reason, the build is not performed, nothing gets deployed, 
 and GitHub is notified of the failure.
 
 ==== Deployment of a successful release

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -97,7 +97,7 @@ as that is the simplest.
 Once ready to create a new release of his plugin, Karl merges some changes to the `master` branch. 
 At which point, the following takes place under the covers: 
 
-1. A webhook is sent to the webhook receiver by GitHub
+1. A webhook is sent to a webhook receiver by GitHub
 
 2. The webhook receiver forwards this hook to a trusted CI server, which is protected by a VPN
 
@@ -262,6 +262,28 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 * Human readable
 * In use by things like the Kubernetes plugin
 * Easily parsed by any number of publicly available libraries
+
+=== Webhooks and the Webhook Receiver
+Webhooks will be used to trigger the builds on the trusted CI server. The hooks themselves 
+will be configured on a per-repository basis. The reasons for choosing individual hooks, 
+as opposed to an organization wide hook, are:
+
+* Security of the build systems. Because this trusted CI server will reside on a non-public 
+network, there needs to be a proxy server of sorts, which can accept these webhooks and send 
+them, securely, to the trusted CI server.
+
+
+* Traceability. An organization-wide webhook would send those hooks to the receiver far more 
+often than is actually necessary. In the event that something goes wrong with this process - 
+the receiver goes down, there is a network outage, etc. - it will be easier for the Infra 
+team to triage problems if they're only looking at hooks from plugins which are intended 
+to be released via CD.
+
+* Flexibility for plugin maintainers. Let's say that Karl maintains two plugins - his archaic 
+`old-timey-plugin`, and his fancy new `karl-plugin` which we've already talked about. If 
+Karl wants to use CD on karl-plugin, but continue to release `old-timey-plugin` from his laptop 
+like he's always done, he can do so, by only setting the webhook up on `karl-plugin`.
+
 
 === Testing Considerations
 Continuous Delivery brings with it a heightened importance for quality automated tests. However, 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -229,7 +229,6 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 * Human readable
 * In use for things like the Kubernetes plugin
 * Easily parsed by any number of publily available libraries
-* 
 
 == Backwards Compatibility
 
@@ -246,13 +245,13 @@ maintainers will see no change at all to the way they do their Jenkins plugin wo
 
 Autorelease should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
 can be put in place on `${trusted-ci-server}` which prevent people from doing silly things.
-It also eliminates the potential for MitM attacks.
 
 == Infrastructure Requirements
 
 We will need:
 
 1. The webhook. Security implications of this are a bit beyond the scope of this document so far.
+ALSO a receiver for the webhook. This 
 2. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
 `Autorelease.yaml` file, and act according to its settings 
 3. Probably `buildPlugin` will need some code added to validate the contents of `Autorelease.yaml`. 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -92,6 +92,8 @@ as that is the simplest.
 
 4. Add a file to the top directory of his repository called `Autorelease.yaml`. 
 
+WARNING: *jvz* Couldn't this be done as an argument to buildPlugin()?
+
 5. A webhook is configured on Karl's repository on GitHub to point to a webhook receiver. 
 
 Once ready to create a new release of his plugin, Karl merges some changes to the `master` branch. 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -220,15 +220,29 @@ credibility in an increasingly demanding market space.
 === Why a trusted CI system?
 Containment of credentials. By using a single system of record for these builds, a service account, maintained by the JENKINS-CERT team, can be used to access GitHub, deploy to Nexus, and deploy to the update centers.
 
+=== Why YAML?
+YAML is becoming increasingly common in the Jenkins community, for many reasons. YAML is:
+
+* Already in use by the Tekton project in Jenkins-X
+* Human readable
+* In use for things like the Kubernetes plugin
+* Easily parsed by any number of publily available libraries
+* 
+
 == Backwards Compatibility
+
+Autorelease introduces no new risks with regard to backwards compatibility or a lack thereof.
 
 With any plugin upgrade, there are backwards compatibility concerns, and Autorelease is no different 
 in that regard. Without Autorelease, there is still nothing stopping a plugin maintainer from releasing 
 a backwards-breaking change.
 
+Plugin maintainers are also not required to use Autorelease at all. By taking no action, these 
+maintainers will see no change at all to the way they do their Jenkins plugin work.
+
 == Security
 
-This should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
+Autorelease should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
 can be put in place on `${trusted-ci-server}` which prevent people from doing silly things.
 It also eliminates the potential for MitM attacks.
 
@@ -236,7 +250,7 @@ It also eliminates the potential for MitM attacks.
 
 We will need:
 
-1. The webhook. 
+1. The webhook. Security implications of this are a bit beyond the scope of this document so far.
 2. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
 `Autorelease.yaml` file, and act according to its settings 
 3. Probably `buildPlugin` will need some code added to validate the contents of `Autorelease.yaml`. 
@@ -247,8 +261,9 @@ people start using it.
 == Testing
 
 Autorelease brings with it a heightened importance for quality automated tests. However, there will be 
-no rules governing this. As before, plugin maintainers are encouraged to release only well-tested code, but
-there is little to stop someone from releasing something which is under-tested. Autorelease does not change this in any way.
+no rules governing this. As is the case today, plugin maintainers are encouraged to release only 
+well-tested code, but there is little to stop someone from releasing something which is under-tested. 
+Autorelease does not change this in any way.
 
 == Prototype Implementation
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -64,8 +64,8 @@ endif::[]
 
 == Abstract
 
-This JEP introduces a new system, which enables Jenkins plugin maintainers to add Continuous 
-Delivery to their projects. It is:
+This JEP introduces a new system which enables Jenkins plugin maintainers to add Continuous Delivery (CD) to their projects.
+It is:
 
 * Opt-in: plugin maintainers can choose to use this
 * Simple to configure: very little needs to be changed in order to enable CD
@@ -155,10 +155,11 @@ For this example plugin, Karl has set the value to `3`, because he's usuing sema
 
 ==== Maven POM file changes
 
-Karl's plugin is already making use of Incrementals, and the relevant lines of his `pom.xml` file 
+Karl's plugin is already making use of link:https://github.com/jenkinsci/incrementals-tools/blob/master/README.md#usage-in-plugin-poms[Incrementals], and the relevant lines of his `pom.xml` file 
 look like:
 
-```
+[source,xml]
+----
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -238,7 +239,7 @@ sense -- and builds credibility -- for the Jenkins developer community to adopt 
 Having a centralized release system made available to plugin maintainers also provides additional 
 confidence that security best practices are being followed. 
 
-Continuous delivery from trusted CI is something which plugin maintainers can opt into, but is 
+Continuous delivery from trusted CI is something which plugin maintainers can opt in to, but is 
 not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
 versions of their code, they remain free to do so.
 
@@ -264,9 +265,9 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 
 * Human readable
 * In use by things like the Kubernetes plugin
-* Easily parsed by any number of publily available libraries
+* Easily parsed by any number of publicly available libraries
 
-=== Aren't we missing some details about infrastructrue requirements?
+=== Aren't we missing some details about infrastructure requirements?
 
 In short, yes, we are. This JEP exists to get the conversation started. Once consensus has been reached, 
 a separate Infrastructure Enhancement Proposal (IEP) will be created to go along with this JEP. It would 
@@ -289,12 +290,12 @@ maintainers will see no change at all to the way they do their Jenkins plugin wo
 == Security
 
 Autorelease can help to make Jenkins plugins, and their release processes, more secure in a 
-number of ways. Including, but not limited to:
+number of ways, including but not limited to:
 
 === Containment of credentials
 
 By using a single system of record for these builds, a service account, maintained by the 
-JENKINS-CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
+Jenkins CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
 the update centers. Plugin maintainers need not leave their own credentials on a CI server 
 which they don't own, and permissions already in place in their GitHub repositories provide 
 the required controls over who can merge and release.

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -252,11 +252,12 @@ the ability to predictably sort them, so that external systems, such as the Jenk
 can correctly publish the "newest" version. The addition of a merge SHA also allows for at-a-glance 
 feedback to tell people which commits went into the release.
 
-NOTE: This version number management scheme is only one of several possible choices. We expect 
-some _lively debate_ around this topic. But it's very important to ensure that versions can be 
-easily sorted by systems such as the Jenkins update center. Also under consideration is defining 
-a fixed number of fields in version numbers, and considering any deviation from that a validation 
-failure.
+WARNING: We know the problem of consistent version numbering, and the resulting ability to 
+sort versions, is important. The scheme discussed here is only one of several possible 
+choices. We expect some _lively debate_ around this topic. But it's very important to ensure 
+that versions can be easily sorted by systems such as the Jenkins update center. Also under 
+consideration is defining a fixed number of fields in version numbers, and considering any 
+deviation from that a validation failure.
 
 === Why YAML?
 YAML is becoming increasingly common in the Jenkins community, for many reasons. YAML is:

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -200,7 +200,7 @@ The commonly used library link:https://github.com/jenkins-infra/pipeline-library
 markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
 released. 
 
-Validation will include:
+Validation must include, but will not be limited to, the following:
 
 1. `pluginName` field must match the repository name
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -68,7 +68,7 @@ At present, Jenkins plugins are, typically, not released on a continous basis. T
 are also not released from a single source of truth, such as a trusted Continuous 
 Integration server like link:https://ci.jenkins.io[https://ci.jenkins.io]. 
 
-The notion of continuous delivery of plugin releases has been discussed previously *need footnote*. 
+The notion of continuous delivery of plugin releases has been discussed previously <<footnote-1,^(1)^>>.
 Considering that Jenkins is a system used to facilitate Continuous Delivery for many users, it makes 
 sense -- and builds credibility -- for the Jenkins developer community to adopt this same practice. 
 
@@ -89,20 +89,27 @@ link:https://github.com/jenkinsci/[the jenkinsci organization on GitHub], a webh
 `super-trusted-ci.jenkins.io`. The specifics of this webhook, and the trusted CI server `super-trusted`, 
 will be described on their own in an IEP document.
 
-We use semantic versioning, because such version numbers are generally well understood by the Jenkins 
-community at large.
+We suggest the use of 
+link:https://semver.org/[semantic versioning], although it is not required.
 
 === Setup
 
-==== The autorelease Maven profile
+Setup could be as simple as making two changes to the way plugins are released. 
+The first of which would be changes to the 
+link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] shared 
+library, which is commonly used to build Jenkins plugins. 
 
-I actually don't know that this is necessary. A new Maven profile can be created, 
+==== [line-through]#The autorelease Maven profile#
+
+[line-through]#I actually don't know that this is necessary. A new Maven profile can be created, 
 most likely in the 
-link:https://github.com/jenkinsci/plugin-pom[Jenkins plugin parent POM]. 
+link:https://github.com/jenkinsci/plugin-pom[Jenkins plugin parent POM].#
 
 ==== Changes to `buildPlugin`
 
-The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, a markerfile, called `Autorelease.yaml`.
+The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, a markerfile, called `Autorelease.yaml`. This 
+markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
+released.
 
 ==== Autorelease.yaml
 
@@ -199,7 +206,7 @@ metadata:
 When Karl merges a commit into the `release-the-fanciness` branch, that merge commit has the 
 SHA `1a2b3c4`. The following takes place:
 
-* A webhook is sent to super-trusted-thing, and a build is performed there. 
+* A webhook is sent to `${trusted-ci-server}`, and a build is performed there. 
 * If the build passes all its tests, a release is generated. In our example, 
 that release number would be `3.1.4-1a2b3c4`, because Karl has chosen to append the merge commit 
 SHA to the end of his autorelease version numbers.
@@ -231,8 +238,8 @@ existing plugin system only allows for uninstalling one revision.
 
 == Security
 
-This should make things more secure, because they all come from a trusted CI. Rules 
-can be put in place on this trusted CI system which prevent people from doing silly things.
+This should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
+can be put in place on `${trusted-ci-server}` which prevent people from doing silly things.
 It also eliminates the potential for MitM attacks.
 
 == Infrastructure Requirements
@@ -266,7 +273,7 @@ be made available before this JEP is given
 
 == References
 
-None yet.
+[[footnote-1]]1. Jenkins World 2017, Contributor Summit Notes, pp. 11-12
 
 
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -97,7 +97,7 @@ as that is the simplest.
 Once ready to create a new release of his plugin, Karl merges some changes to the `master` branch. 
 At which point, the following takes place under the covers: 
 
-1. A webhook is sent to the webhook receier by GitHub
+1. A webhook is sent to the webhook receiver by GitHub
 
 2. The webhook receiver forwards this hook to a trusted CI server, which is protected by a VPN
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -211,7 +211,7 @@ and GitHub is notified of the failure.
 
 ==== Deployment of a successful release
 
-When Karl merges a commit into the `master` branch, that merge commit is commit number 150, and has the 
+When Karl merges a commit into the `master` branch, that merge commit is link:https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc#basic-usage[commit number] 150, and has the 
 SHA `1a2b3c4`. The following takes place:
 
 * A webhook is sent to `${trusted-ci-server}`, and `Autorelease.yaml` is validated.

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -279,7 +279,7 @@ be made available before this JEP is given
 
 == References
 
-[[footnote-1]]1. Jenkins World 2017, Contributor Summit Notes, pp. 11-12
+[[footnote-1]]1. Jenkins World 2017, link:http://bit.ly/2x1lCUZ[Contributor Summit Notes], pp. 11-12
 
 
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -1,4 +1,4 @@
-= JEP-0000: Opt-in Continuous Delivery of Jenkins Plugin Releases
+= JEP-0000: Continuous Delivery of Jenkins Plugins
 :toc: preamble
 :toclevels: 3
 ifdef::env-github[]

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -16,7 +16,7 @@ endif::[]
 | 0000
 
 | Title
-| Opt-in Continuous Delivery of Jenkins Plugin Releases from Trusted CI
+| Continuous Delivery of Jenkins Plugins
 
 | Sponsor
 | link:https://github.com/daniel-beck[Daniel Beck]

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -225,13 +225,12 @@ SHA `1a2b3c4`. The following takes place:
 the trusted CI server.
 * `Autorelease.yaml` is validated.
 * Once validation passes, a build is performed. If the build passes all its tests, a release 
-
-WARNING: Some clarification needed based on https://github.com/jenkinsci/jep/pull/244/files#r293536274 .
-
 is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
 * The built plugin gets deployed to Artifactory
 * link:https://github.com/jenkins-infra/update-center2/blob/master/README.md[The UC generator] makes
 the plugin available on the Jenkins Update Center, as Karl Plugin version `3.1.4-150-1a2b3c4`.
+
+WARNING: Some clarification needed based on https://github.com/jenkinsci/jep/pull/244/files#r302487016.
 
 == Motivation
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -320,6 +320,8 @@ build the plugin according to the settings described therein
 5. Service account(s), managed by the Jenkins Infrastructure team, which provide secure credentials 
 to systems such as Artifactory
 
+CAUTION: TODO: Things such as service accounts and new servers will be handled in a separate IEP.
+
 == Testing
 
 Autorelease brings with it a heightened importance for quality automated tests. However, there will be 
@@ -342,15 +344,3 @@ be made available before this JEP is given
 == References
 
 [[footnote-1]]1. Jenkins World 2017, link:http://bit.ly/2x1lCUZ[Contributor Summit Notes], pp. 11-12
-
-
-
-
-We need to either enforce a fixed number of elements in version numbers,
-OR
-have it confiurable, so that:
-    - More than the spec, gets rejected
-    - Less than the spec, `0` gets appended
-
-We know the problem, fixed length is one approach to fixing it.
-

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -202,6 +202,12 @@ Validation must include, but will not be limited to, the following:
 set to `3` (three fields), and the `revision` in `pom.xml` is set to `3.1.4.5` (four fields), validation 
 will fail.
 
+[WARNING]
+====
+*(bitwiseman)* 
+There's a long thread here: https://github.com/jenkinsci/jep/pull/244/files#r293534268 that needs to be integrated into this. 
+====
+
 3. Validation that no extra fields are present in the file. Comments are allowed, but any unexpected 
 lines will cause validation to fail.
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -88,8 +88,7 @@ using `buildPlugin` when built on ci.jenkins.io.
 2. Choose a branch from which to release. Karl decides he wants to release from the `master` branch, 
 as that is the simplest.
 
-3. Settle on a version numbering scheme. Becuase it's in fairly wide use across the Jenkins 
-ecosystem, Karl settles on link:https://semver.org/[semantic versioning].
+3. Settle on a version numbering scheme. Karl decides on link:https://semver.org/[semantic versioning].
 
 4. Add a file to the top directory of his repository called `Autorelease.yaml`. 
 
@@ -192,7 +191,7 @@ No additional changes need to be made to `pom.xml` by Karl, he's good to go.
 ==== Autorelease.yaml verification in `buildPlugin`
 
 The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for the presence of, and validate, `Autorelease.yaml`. This 
-markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
+markerfile will be the mechanism that tells the trusted CI server that this plugin should be automatically 
 released. 
 
 Validation must include, but will not be limited to, the following:
@@ -214,11 +213,14 @@ and GitHub is notified of the failure.
 When Karl merges a commit into the `master` branch, that merge commit is link:https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc#basic-usage[commit number] 150, and has the 
 SHA `1a2b3c4`. The following takes place:
 
-* A webhook is sent to `${trusted-ci-server}`, and `Autorelease.yaml` is validated.
+* A webhook is sent from GitHub, to the webhook receiver. That hook is forwarded  to 
+the trusted CI server.
+* `Autorelease.yaml` is validated.
 * Once validation passes, a build is performed. If the build passes all its tests, a release 
 is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
 * The built plugin gets deployed to Artifactory
-* The resulting plugin appears on the Jenkins Update Center, as Karl Plugin version `3.1.4-150-1a2b3c4`.
+* link:https://github.com/jenkins-infra/update-center2/blob/master/README.md[The UC generator] makes
+the plugin available on the Jenkins Update Center, as Karl Plugin version `3.1.4-150-1a2b3c4`.
 
 == Motivation
 
@@ -261,6 +263,12 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 * In use by things like the Kubernetes plugin
 * Easily parsed by any number of publicly available libraries
 
+=== Testing Considerations
+Continuous Delivery brings with it a heightened importance for quality automated tests. However, 
+there will be no rules governing this. As is the case today, plugin maintainers are encouraged to 
+release only well-tested code, but there is little to stop someone from releasing something which 
+is under-tested. Continuous delivery does not change this in any way.
+
 === Aren't we missing some details about infrastructure requirements?
 
 In short, yes, we are. This JEP exists to get the conversation started. Once consensus has been reached, 
@@ -269,17 +277,13 @@ be premature to describe every detail of implementation before consensus is reac
 
 == Backwards Compatibility
 
-Autorelease introduces no new risks with regard to backwards compatibility of plugins themselves. 
-However, there will be a requirement for plugin maintainers to use a consistent version numbering 
-scheme. Consistent version numbering will prevent problems with sorting versions. This is discussed 
-elsewhere in this document.
+Plugin maintainers will need to be mindful of the fact that merging a PR to their `triggeringBranch` 
+constitutes a public release. For this reason, the `triggeringBranch` setting in `Autorelease.yaml` can 
+be set to something other than `master`, should the maintainer wish to do so.
 
-With any plugin upgrade, there are backwards compatibility concerns, and Autorelease is no different 
-in that regard. Without Autorelease, there is still nothing stopping a plugin maintainer from releasing 
-a backwards-breaking change.
-
-Plugin maintainers are also not required to use Autorelease at all. By taking no action, these 
-maintainers will see no change at all to the way they do their Jenkins plugin work.
+Continuous delivery introduces no new risks with regard to backwards compatibility of plugins 
+themselves. Even without it, there is still nothing stopping a plugin maintainer from releasing 
+a backwards-breaking change. 
 
 == Security
 
@@ -292,11 +296,12 @@ By using a single system of record for these builds, a service account, maintain
 Jenkins CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
 the update centers. Plugin maintainers need not leave their own credentials on a CI server 
 which they don't own, and permissions already in place in their GitHub repositories provide 
-the required controls over who can merge and release.
+the required controls over who can merge and release. What's more, they need not have 
+Artifactory credentials at all.
 
 === Automatic enforcement of security best practices
-Autorelease builds will all come from `${trusted-ci-server}`. Rules 
-can be put in place on `${trusted-ci-server}`, which can provide implicit enforcement of the 
+Autorelease builds will all come from a trusted CI server, which resides on a VPN. Rules 
+can be put in place on this CI server, which can provide implicit enforcement of the 
 Jenkins infrastructure team's security best practices. Compliance to these best practices becomes 
 something that plugin maintainers need not worry about.
 
@@ -305,9 +310,10 @@ something that plugin maintainers need not worry about.
 We will need a number of things to get this going. The low-level technical details will be described 
 in a separate Infrastructure Enhancement Request, so, this should be considered a summary for now:
 
-1. The webhook, configured on each participating plugin. Security implications of this are a bit beyond the scope of this document so far.
-2. [[webhook-receiver]]A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
-behind a VPN
+1. The webhook, configured on each participating plugin. Security implications of this are a bit 
+beyond the scope of this document so far.
+2. [[webhook-receiver]]A receiver for the aforementioned webhook, because the trusted CI 
+server will be protected behind a VPN
 3. A trusted Jenkins server for performing builds and deployments. 
 4. `buildPlugin` will need code added to validate `Autorelease.yaml` for correctness, and 
 build the plugin according to the settings described therein
@@ -318,10 +324,8 @@ CAUTION: TODO: Things such as service accounts and new servers will be handled i
 
 == Testing
 
-Autorelease brings with it a heightened importance for quality automated tests. However, there will be 
-no rules governing this. As is the case today, plugin maintainers are encouraged to release only 
-well-tested code, but there is little to stop someone from releasing something which is under-tested. 
-Autorelease does not change this in any way.
+Testing of this process will be performed interactively. The biggest code change involved here 
+will be the validation getting added to `buildPlugin`.
 
 == Prototype Implementation
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -141,7 +141,9 @@ autorelease, this will only be set to `plugin`. The field is here should the Jen
 want to expand the use of autorelease, such as for building core, or components
 `metadata`:: 
 Contains the following fields:
-** `autoreleaseEnabled`: A boolean value, indicating whether or not this plugin is participating in autorelease
+** `autoreleaseEnabled`: A boolean value, indicating whether or not this plugin is participating 
+in autorelease. Allows the maintainer to turn Autorelease on or off, without deleting the file 
+entirely.
 ** `triggeringBranch`: Sets the branch which maintainers will merge to in order to trigger 
 an autorelease webhook. Although this is expected to usually be set to `master`, plugin 
 maintainers can choose a branch name of their preference, e.g., `autorelease`, `release`, 
@@ -194,21 +196,23 @@ No additional changes need to be made to `pom.xml` by Karl, he's good to go.
 
 ==== Autorelease.yaml verification in `buildPlugin`
 
-The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, the markerfile, called `Autorelease.yaml`. This 
+The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for the presence of, and validate, `Autorelease.yaml`. This 
 markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
-released.
+released. 
 
 Validation will include:
 
 1. `pluginName` field must match the repository name
 
 2. `versionNumberFields` must match the `revision` property in `pom.xml`. E.g., if `versionNumberFields` is 
-set to `3`, and the `revision` is set to `3.1.4.5`, validation will fail.
+set to `3` (three fields), and the `revision` in `pom.xml` is set to `3.1.4.5` (four fields), validation 
+will fail.
 
 3. Validation that no extra fields are present in the file. Comments are allowed, but any unexpected 
 lines will cause validation to fail.
 
-If validation of `Autorelease.yaml` fails for any reason, the build is not performed and nothing gets deployed.
+If validation of `Autorelease.yaml` fails for any reason, the build is not performed nothing gets deployed, 
+and GitHub is notified of the failure.
 
 ==== Deployment of a successful release
 
@@ -218,8 +222,8 @@ SHA `1a2b3c4`. The following takes place:
 * A webhook is sent to `${trusted-ci-server}`, and `Autorelease.yaml` is validated.
 * Once validation passes, a build is performed. If the build passes all its tests, a release 
 is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
-* The built plugin gets deployed to Nexus
-* The resulting plugin appears on the Jenkins Update Center, as Fancy Branch Plugin version 3.1.4-150-1a2b3c
+* The built plugin gets deployed to Artifactory
+* The resulting plugin appears on the Jenkins Update Center, as Fancy Branch Plugin version `3.1.4-150-1a2b3c`.
 
 == Motivation
 
@@ -232,8 +236,7 @@ Considering that Jenkins is a system used to facilitate Continuous Delivery for 
 sense -- and builds credibility -- for the Jenkins developer community to adopt this same practice. 
 
 Having a centralized release system made available to plugin maintainers also provides additional 
-confidence that security best practices are being followed *need footnote without surfacing some 
-awful security problem* 
+confidence that security best practices are being followed. 
 
 Continuous celivery from trusted CI is something which plugin maintainers can opt into, but is 
 not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
@@ -244,21 +247,23 @@ versions of their code, they remain free to do so.
 === What's with the version numbering?
 
 Jenkins plugin maintainers are already familiar with the way that Incrementals appends a commit 
-number, pluse a merge SHA, to version numbers. These mechanically-generated version numbers offer 
+number, plus a SHA, to version numbers. These mechanically-generated version numbers offer 
 the ability to predictably sort them, so that external systems, such as the Jenkins update center, 
 can correctly publish the "newest" version. The addition of a merge SHA also allows for at-a-glance 
 feedback to tell people which commits went into the release.
 
 NOTE: This version number management scheme is only one of several possible choices. We expect 
-some lively debate around this topic. But it's very important to ensure that versions can be 
-easily sorted by systems such as the Jenkins update center.
+some _lively debate_ around this topic. But it's very important to ensure that versions can be 
+easily sorted by systems such as the Jenkins update center. Also under consideration is defining 
+a fixed number of fields in version numbers, and considering any deviation from that a validation 
+failure.
 
 === Why YAML?
 YAML is becoming increasingly common in the Jenkins community, for many reasons. YAML is:
 
 * Already in use by the Tekton project in Jenkins-X
 * Human readable
-* In use for things like the Kubernetes plugin
+* In use by things like the Kubernetes plugin
 * Easily parsed by any number of publily available libraries
 
 === Aren't we missing some details about infrastructrue requirements?
@@ -283,13 +288,16 @@ maintainers will see no change at all to the way they do their Jenkins plugin wo
 
 == Security
 
-Autorelease can make things more secure
+Autorelease can help to make Jenkins plugins, and their release processes, more secure in a 
+number of ways. Including, but not limited to:
 
 === Containment of credentials
 
 By using a single system of record for these builds, a service account, maintained by the 
 JENKINS-CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
-the update centers.
+the update centers. Plugin maintainers need not leave their own credentials on a CI server 
+which they don't own, and permissions already in place in their GitHub repositories provide 
+the required controls over who can merge and release.
 
 === Automatic enforcement of security best practices
 Autorelease builds will all come from `${trusted-ci-server}`. Rules 
@@ -299,17 +307,17 @@ something that plugin maintainers need not worry about.
 
 == Infrastructure Requirements
 
-We will need:
+We will need a number of things to get this going. The low level technical details will be described 
+in a separate Infrastructure Enhancement Request, so, this should be considered a summary for now:
 
 1. The webhook, configured on each participating plugin . Security implications of this are a bit beyond the scope of this document so far.
-ALSO a receiver for the webhook. This 
 2. A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
 behind a VPN
-3. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
-`Autorelease.yaml` file, and act according to its settings 
-4. `buildPlugin` will need some code added to validate `Autorelease.yaml` for correctness, and 
+3. A trusted Jenkins server for performing builds and deployments. 
+4. `buildPlugin` will need code added to validate `Autorelease.yaml` for correctness, and 
 build the plugin according to the settings described therein
-5. Perhaps a mechanism by which we can verify the authenticity of incoming build requests. But this should be handled by GitHub repository permissions themselves. In other words, if Janet Plugin has merge rights to `the-janet-plugin`, she has that already today.
+5. Service account(s), managed by the Jenkins Infrastructure team, which provide secure credentials 
+to systems such as Artifactory
 
 == Testing
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -9,27 +9,6 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-.**JEP Template**
-[TIP]
-====
-In this document, all text in a "Tip" block (or inline text with with a ":bulb:" on either side)
-MUST be removed and/or replaced with text appropriate to this JEP before submission.
-
-Sections may include aditional help and advice in comments.
-":bulb:" entries in comments only need to be filled in if that text is uncommented.
-
-See https://github.com/jenkinsci/jep/blob/master/jep/1/README.adoc[JEP-1] for full and accurate description of the JEP process and what is required in each section.
-====
-
-[TIP]
-====
-*BDFL-Delegate* is uncommented by default.
-As part of the in initial conversation or the JEP submission the sponsor should
-look for a BDFL Delegate.
-While not required, it is better for the community if Delegates perform most reviews.
-If no suitable BDFL-Delegate can be found, that row may be commented out.
-====
-
 .Metadata
 [cols="1h,1"]
 |===

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -1,0 +1,316 @@
+= JEP-0000: Opt-in Continuous Delivery of Jenkins Plugin Releases
+:toc: preamble
+:toclevels: 3
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+.**JEP Template**
+[TIP]
+====
+In this document, all text in a "Tip" block (or inline text with with a ":bulb:" on either side)
+MUST be removed and/or replaced with text appropriate to this JEP before submission.
+
+Sections may include aditional help and advice in comments.
+":bulb:" entries in comments only need to be filled in if that text is uncommented.
+
+See https://github.com/jenkinsci/jep/blob/master/jep/1/README.adoc[JEP-1] for full and accurate description of the JEP process and what is required in each section.
+====
+
+[TIP]
+====
+*BDFL-Delegate* is uncommented by default.
+As part of the in initial conversation or the JEP submission the sponsor should
+look for a BDFL Delegate.
+While not required, it is better for the community if Delegates perform most reviews.
+If no suitable BDFL-Delegate can be found, that row may be commented out.
+====
+
+.Metadata
+[cols="1h,1"]
+|===
+| JEP
+| 0000
+
+| Title
+| Opt-in Continuous Delivery of Jenkins Plugin Releases from Trusted CI
+
+| Sponsor
+| link:https://github.com/daniel-beck[Daniel Beck]
+
+// Use the script `set-jep-status <jep-number> <status>` to update the status.
+| Status
+| Draft :speech_balloon:
+
+| Type
+| Process :bulb:
+
+| Created
+| Date (2019-05-15) :bulb:
+
+| BDFL-Delegate
+| TBD
+
+//
+//
+// Uncomment if there is an associated placeholder JIRA issue.
+//| JIRA
+//| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-nnnnn[JENKINS-nnnnn] :bulb:
+//
+//
+// Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.
+//| Discussions-To
+//| :bulb: Link to where discussion and final status announcement will occur :bulb:
+//
+//
+// Uncomment if this JEP depends on one or more other JEPs.
+//| Requires
+//| :bulb: JEP-NUMBER, JEP-NUMBER... :bulb:
+//
+//
+// Uncomment and fill if this JEP is rendered obsolete by a later JEP
+//| Superseded-By
+//| :bulb: JEP-NUMBER :bulb:
+//
+//
+// Uncomment when this JEP status is set to Accepted, Rejected or Withdrawn.
+//| Resolution
+//| :bulb: Link to relevant post in the jenkinsci-dev@ mailing list archives :bulb:
+
+|===
+
+== Abstract
+
+At present, Jenkins plugins are, typically, not released on a continous basis. They 
+are also not released from a single source of truth, such as a trusted Continuous 
+Integration server like link:https://ci.jenkins.io[https://ci.jenkins.io]. 
+
+The notion of continuous delivery of plugin releases has been discussed previously *need footnote*. 
+Considering that Jenkins is a system used to facilitate Continuous Delivery for many users, it makes 
+sense -- and builds credibility -- for the Jenkins developer community to adopt this same practice. 
+
+Having a centralized release system made available to plugin maintainers also provides additional 
+confidence that security best practices are being followed *need footnote without surfacing some 
+awful security problem* 
+
+Continuous celivery from trusted CI is something which plugin maintainers can opt into, but is 
+not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
+versions of their code, they remain free to do so.
+
+== Specification
+
+This proposal describes an approach by which plugin maintainers can have merges to a branch of their 
+choice occur, an automated release process is launched. It is anticipated that the typical scenario 
+will be `master`. In other words, once a commit is merged to master in the repository hosted in 
+link:https://github.com/jenkinsci/[the jenkinsci organization on GitHub], a webhook will be sent to 
+`super-trusted-ci.jenkins.io`. The specifics of this webhook, and the trusted CI server `super-trusted`, 
+will be described on their own in an IEP document.
+
+We use semantic versioning, because such version numbers are generally well understood by the Jenkins 
+community at large.
+
+=== Setup
+
+Two main things:
+
+A new Maven profile will be created, most likely in the 
+link:https://github.com/jenkinsci/plugin-pom[Jenkins plugin parent POM]. 
+
+* enable-autorelease
+
+A YAML markerfile, stored in the plugin's own repository. Absence of this markerfile will In the following example, we'll use a fictional plugin, called `fancy-branch-source`
+
+```
+plugin: fancy-branch-source
+kind: plugin
+metadata:
+  autoreleaseEnabled: true
+  triggeringBranch: master
+  appendMergeSHA: true
+```
+
+In the above example, we can see the following:
+
+`plugin: fancy-branch-source`:: 
+This is the name of the plugin, and it matches the repository 
+name on GitHub.
+`kind`:: 
+The type of project which is being set up for autorelease. In our first iteration of 
+autorelease, this will only be set to `plugin`. The field is here should the Jenkins project 
+want to expand the use of autorelease, such as for building core, or components
+`metadata`:: 
+Contains the following fields:
+** `autoreleaseEnabled`: A boolean value, indicating whether or not this plugin is participating in autorelease
+** `triggeringBranch`: Sets the branch which maintainers will merge to in order to trigger 
+an autorelease webhook. Although this is expected to usually be set to `master`, plugin 
+maintainers can choose a branch name of their preference, e.g., `autorelease`, `release`, 
+etc.
+** `appendMergeSHA`: A boolean value, indicating whether or not the resultant release will 
+be version numbered including the merge SHA, for example, `2.5.2-1a2b3c4`. This will maintain 
+compatibility with the existing Incrementals versioning.
+
+=== Adoption
+
+To illustrate how this would be used by a plugin maintainer, we'll continue with our fictional example.
+Plugin maintainer Karl has decided that he would like to automatically release fancy-branch-source 
+automatically, each time he merges to a branch called `release-the-fanciness`. 
+
+Karl's plugin is already making use of Incrementals, and the relevant lines of his `pom.xml` file 
+look like:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.56</version>
+        <relativePath />
+    </parent>
+    <artifactId>fancy-branch-source</artifactId>
+    <version>${revision}${changelist}</version>
+    <packaging>hpi</packaging>
+    <name>Fancy Branch Source Plugin</name>
+    <url>
+        <!--Something like https://wiki.jenkins-ci.org/display/JENKINS/Fancy+Branch+Source+Plugin-->
+    </url>
+    <description>A useful description.</description>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <revision>3.1.4</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <java.level>8</java.level>
+        <jenkins.version>2.138.4</jenkins.version>
+    </properties>
+
+````
+
+This is all pretty run-of-the-mill stuff for a Jenkins plugin, and is well understood already 
+by Karl and the rest of the plugin maintainer community. To enable autorelease, Karl would 
+create a file at the top level of his repository, called `Autorelease.yaml`:
+
+```
+plugin: fancy-branch-source
+kind: plugin
+metadata:
+  autoreleaseEnabled: true
+  triggeringBranch: release-the-fanciness
+  appendMergeSHA: true
+```
+
+When Karl merges a commit into the `release-the-fanciness` branch, that merge commit has the 
+SHA `1a2b3c4`. The following takes place:
+* A webhook is sent to super-trusted-thing, and a build is performed there. 
+* If the build passes all its tests, a release is generated. In our example, 
+that release number would be `3.1.4-1a2b3c4`, because Karl has chosen to append the merge commit 
+SHA to the end of his autorelease version numbers.
+* The built plugin gets deployed to Nexus
+* The resulting plugin appears on the Jenkins Update Center
+
+== Motivation
+
+It's no secret that the Jenkins plugin ecosystem is complex. It's also no secret that Jenkins plugins 
+are often developed in a very non-continuous way. This proposal seeks to change this. By offering the 
+ability to do continuous, merge-driven releases, plugin maintainers can readily make the claim that 
+Jenkins itself is being worked on in a continuous way. This would be a big win for Jenkins' 
+credibility in an increasingly demanding market space.
+
+[TIP]
+====
+Explain why the existing code base or process is inadequate to address the problem that the JEP solves.
+This section may also contain any historical context such as how things were done before this proposal.
+
+* Do not discuss design choices or alternative designs that were rejected - those belong in the Reasoning section.
+====
+
+== Reasoning
+
+Oh boy the UX for this could really suck. People are going to be overrun with upgrades they think they 
+need to do.
+
+Maybe we need an "urgent" flag for those?
+
+[TIP]
+====
+Explain why particular design decisions were made.
+Describe alternate designs that were considered and related work. For example, how the feature is supported in other systems.
+Provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
+
+* Use sub-headings to organize this section for ease of readability.
+* Do not talk about history or why this needs to be done - that is part of Motivation section.
+====
+
+== Backwards Compatibility
+
+[TIP]
+====
+Describe any incompatibilities and their severity.
+Describe how the JEP proposes to deal with these incompatibilities.
+
+If there are no backwards compatibility concerns, this section may simply say:
+There are no backwards compatibility concerns related to this proposal.
+====
+
+With any plugin upgrade, there are backwards compatibility concerns, and autorelease is no different 
+in that regard. In fact, it could be made worse, because users will get overrun with upgrades. Jenkins 
+existing plugin system only allows for uninstalling one revision. 
+
+
+
+== Security
+
+This should make things more secure, because they all come from a trusted CI. Rules 
+can be put in place on this trusted CI system which prevent people from doing silly things.
+It also eliminates the potential for MitM attacks.
+
+== Infrastructure Requirements
+
+We will need:
+1. The webhook. 
+2. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
+`Autorelease.yaml` file, and act according to its settings
+3. Probably `buildPlugin` will need some code added to validate the contents of `Autorelease.yaml`. 
+Otherwise there's no telling what people might put in there. This needs to be well-hardened before 
+people start using it.
+
+== Testing
+
+Autorelease brings with it a heightened importance for quality automated tests. However, there will be 
+no rules governing this. As before, plugin maintainers are encouraged to release only well-tested code, but
+there is little to stop someone from releasing something which is under-tested. Autorelease does not change 
+this in any way.
+
+== Prototype Implementation
+
+[TIP]
+====
+Link to any open source reference implementation of code changes for this proposal.
+The implementation need not be completed before the JEP is
+link:https://github.com/jenkinsci/jep/tree/master/jep/1#accepted[accepted],
+but must be completed before any JEP is given
+"link:https://github.com/jenkinsci/jep/tree/master/jep/1#final[Final]" status.
+
+JEPs which will not include code changes may omit this section.
+====
+
+== References
+
+[TIP]
+====
+Provide links to any related documents.
+This will include links to discussions on the mailing list, pull requests, and meeting notes.
+====
+
+
+

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -283,18 +283,11 @@ as opposed to an organization wide hook, are:
 network, there needs to be a proxy server of sorts, which can accept these webhooks and send 
 them, securely, to the trusted CI server.
 
-
 * Traceability. An organization-wide webhook would send those hooks to the receiver far more 
 often than is actually necessary. In the event that something goes wrong with this process - 
 the receiver goes down, there is a network outage, etc. - it will be easier for the Infra 
 team to triage problems if they're only looking at hooks from plugins which are intended 
 to be released via CD.
-
-* Flexibility for plugin maintainers. Let's say that Karl maintains two plugins - his archaic 
-`old-timey-plugin`, and his fancy new `karl-plugin` which we've already talked about. If 
-Karl wants to use CD on karl-plugin, but continue to release `old-timey-plugin` from his laptop 
-like he's always done, he can do so, by only setting the webhook up on `karl-plugin`.
-
 
 === Testing Considerations
 Continuous Delivery brings with it a heightened importance for quality automated tests. However, 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -99,12 +99,6 @@ The first of which would be changes to the
 link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] shared 
 library, which is commonly used to build Jenkins plugins. 
 
-==== [line-through]#The autorelease Maven profile#
-
-[line-through]#I actually don't know that this is necessary. A new Maven profile can be created, 
-most likely in the 
-link:https://github.com/jenkinsci/plugin-pom[Jenkins plugin parent POM].#
-
 ==== Changes to `buildPlugin`
 
 The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, a markerfile, called `Autorelease.yaml`. This 
@@ -223,18 +217,14 @@ credibility in an increasingly demanding market space.
 
 == Reasoning
 
-=== Why Maven?
-With Incrementals having gained fairly wide adoption by plugin maintainers, it seems reasonable to use maven 
-
-
 === Why a trusted CI system?
 Containment of credentials. By using a single system of record for these builds, a service account, maintained by the JENKINS-CERT team, can be used to access GitHub, deploy to Nexus, and deploy to the update centers.
 
 == Backwards Compatibility
 
-With any plugin upgrade, there are backwards compatibility concerns, and autorelease is no different 
-in that regard. In fact, it could be made worse, because users will get overrun with upgrades. Jenkins 
-existing plugin system only allows for uninstalling one revision. 
+With any plugin upgrade, there are backwards compatibility concerns, and Autorelease is no different 
+in that regard. Without Autorelease, there is still nothing stopping a plugin maintainer from releasing 
+a backwards-breaking change.
 
 == Security
 
@@ -245,19 +235,20 @@ It also eliminates the potential for MitM attacks.
 == Infrastructure Requirements
 
 We will need:
+
 1. The webhook. 
 2. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
-`Autorelease.yaml` file, and act according to its settings
+`Autorelease.yaml` file, and act according to its settings 
 3. Probably `buildPlugin` will need some code added to validate the contents of `Autorelease.yaml`. 
 Otherwise there's no telling what people might put in there. This needs to be well-hardened before 
 people start using it.
+4. Perhaps a mechanism by which we can verify the authenticity of incoming build requests. But this should be handled by GitHub repository permissions themselves. In other words, if Janet Plugin has merge rights to `the-janet-plugin`, she has that already today.
 
 == Testing
 
 Autorelease brings with it a heightened importance for quality automated tests. However, there will be 
 no rules governing this. As before, plugin maintainers are encouraged to release only well-tested code, but
-there is little to stop someone from releasing something which is under-tested. Autorelease does not change 
-this in any way.
+there is little to stop someone from releasing something which is under-tested. Autorelease does not change this in any way.
 
 == Prototype Implementation
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -315,7 +315,7 @@ number of ways, including but not limited to:
 === Containment of credentials
 
 By using a single system of record for these builds, a service account, maintained by the 
-Jenkins CERT team, can be used to access GitHub, deployment to Nexus, and deployment to 
+Jenkins CERT team, can be used to access GitHub, deploy to Nexus, and thus deploy to 
 the update centers. Plugin maintainers need not leave their own credentials on a CI server 
 which they don't own, and permissions already in place in their GitHub repositories provide 
 the required controls over who can merge and release. What's more, they need not have 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -29,7 +29,7 @@ endif::[]
 | Process :bulb:
 
 | Created
-| Date (2019-05-15) :bulb:
+| :bulb:
 
 | BDFL-Delegate
 | TBD

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -77,7 +77,7 @@ the Jenkins project
 === Overview
 
 We'll use a short story to illustrate what Autorelease will look like when a plugin maintainer 
-named Karl decides that he wants to perform continuous delivery of his Fancy Branch Plugin.
+named Karl decides that he wants to perform continuous delivery of his (fictional) Karl-Plugin.
 
 To do so, Karl will:
 
@@ -119,10 +119,10 @@ A YAML markerfile, stored in the plugin's own repository. Absence of this marker
 be functionally equivalent to the plugin maintainer opting out of Autorelease. 
 
 In the following example, we'll stick with plugin developer Karl, and his fictional 
-plugin `fancy-branch-source`. Karl's `Autorelease.yaml` file looks like this:
+plugin `karl-plugin`. Karl's `Autorelease.yaml` file looks like this:
 
 ```
-plugin: fancy-branch-source
+plugin: karl
 kind: plugin
 metadata:
   autoreleaseEnabled: true
@@ -132,13 +132,13 @@ metadata:
 
 In the above example `Autorelease.yaml`, we can see the following:
 
-`plugin: fancy-branch-source`:: 
+`plugin: karl`:: 
 This is the name of the plugin, and it matches the repository 
 name on GitHub.
 `kind`:: 
 The type of project which is being set up for autorelease. In our first iteration of 
 autorelease, this will only be set to `plugin`. The field is here should the Jenkins project 
-want to expand the use of autorelease, such as for building core, or components
+want to expand the use of autorelease, such as for building core, or components.
 `metadata`:: 
 Contains the following fields:
 ** `autoreleaseEnabled`: A boolean value, indicating whether or not this plugin is participating 
@@ -168,14 +168,14 @@ look like:
         <version>4.56</version>
         <relativePath />
     </parent>
-    <artifactId>fancy-branch-source</artifactId>
+    <artifactId>karl</artifactId>
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
-    <name>Fancy Branch Source Plugin</name>
+    <name>Karl Plugin</name>
     <url>
-        <!--Something like https://wiki.jenkins-ci.org/display/JENKINS/Fancy+Branch+Source+Plugin-->
+        <!--Something like https://wiki.jenkins-ci.org/display/JENKINS/Karl+Plugin-->
     </url>
-    <description>A useful description.</description>
+    <description>A useful description of the Karl plugin.</description>
     <licenses>
         <license>
             <name>MIT</name>
@@ -223,7 +223,7 @@ SHA `1a2b3c4`. The following takes place:
 * Once validation passes, a build is performed. If the build passes all its tests, a release 
 is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
 * The built plugin gets deployed to Artifactory
-* The resulting plugin appears on the Jenkins Update Center, as Fancy Branch Plugin version `3.1.4-150-1a2b3c`.
+* The resulting plugin appears on the Jenkins Update Center, as Karl Plugin version `3.1.4-150-1a2b3c4`.
 
 == Motivation
 
@@ -238,7 +238,7 @@ sense -- and builds credibility -- for the Jenkins developer community to adopt 
 Having a centralized release system made available to plugin maintainers also provides additional 
 confidence that security best practices are being followed. 
 
-Continuous celivery from trusted CI is something which plugin maintainers can opt into, but is 
+Continuous delivery from trusted CI is something which plugin maintainers can opt into, but is 
 not required. If a plugin maintainer chooses to continue to follow their own path for releasing 
 versions of their code, they remain free to do so.
 
@@ -262,7 +262,6 @@ deviation from that a validation failure.
 === Why YAML?
 YAML is becoming increasingly common in the Jenkins community, for many reasons. YAML is:
 
-* Already in use by the Tekton project in Jenkins-X
 * Human readable
 * In use by things like the Kubernetes plugin
 * Easily parsed by any number of publily available libraries

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -366,4 +366,4 @@ be made available before this JEP is given
 
 == References
 
-[[footnote-1]]1. Jenkins World 2017, link:http://bit.ly/2x1lCUZ[Contributor Summit Notes], pp. 11-12
+[[footnote-1]]1. Jenkins World 2017, link:https://docs.google.com/document/d/1JSxYNI_RuA8ITlxVmxBdFg1A-sOKz-w7a9tzuPfWmr4/edit#heading=h.n2d90ci56ugy[Contributor Summit Notes]

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -225,6 +225,9 @@ SHA `1a2b3c4`. The following takes place:
 the trusted CI server.
 * `Autorelease.yaml` is validated.
 * Once validation passes, a build is performed. If the build passes all its tests, a release 
+
+WARNING: Some clarification needed based on https://github.com/jenkinsci/jep/pull/244/files#r293536274 .
+
 is generated. In our example, that release number would be `3.1.4-150-1a2b3c4`
 * The built plugin gets deployed to Artifactory
 * link:https://github.com/jenkins-infra/update-center2/blob/master/README.md[The UC generator] makes

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -74,28 +74,44 @@ the Jenkins project
 
 == Specification
 
-This proposal describes an approach by which plugin maintainers can have merges to a branch of their 
-choice occur, an automated release process is launched. It is anticipated that the typical scenario 
-will be `master`. In other words, once a commit is merged to master in the repository hosted in 
-link:https://github.com/jenkinsci/[the jenkinsci organization on GitHub], a webhook will be sent to 
-`super-trusted-ci.jenkins.io`. The specifics of this webhook, and the trusted CI server `super-trusted`, 
-will be described on their own in an IEP document.
+=== Overview
 
-We suggest the use of 
-link:https://semver.org/[semantic versioning], although it is not required.
+We'll use a short story to illustrate what Autorelease will look like when a plugin maintainer 
+decides that they want to take part.
 
-=== Setup
+Karl, a plugin developer who owns the fancy-branch-plugin, wants to add CD to his project. To do so, 
+he will:
 
-Setup could be as simple as making two changes to the way plugins are released. 
-The first of which would be changes to the 
-link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] shared 
-library, which is commonly used to build Jenkins plugins. 
+1. Verify support. Karl's plugin is already in the jenkinsci Organization on GitHub, and is 
+using `buildPlugin` when built on ci.jenkins.io.
 
-==== Changes to `buildPlugin`
+2. Choose a branch from which to release. Karl decides he wants to release from the `master` branch, 
+as that is the simplest.
 
-The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, a markerfile, called `Autorelease.yaml`. This 
-markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
-released.
+3. Settle on a version numbering scheme. Becuase it's in fairly wide use across the Jenkins 
+ecosystem, Karl settles on link:https://semver.org/[semantic versioning].
+
+4. Add a file to the top directory of his repository called `Autorelease.yaml`. 
+
+5. A webhook is configured on Karl's repository on GitHub to point to `{the-webhook-receiver}`
+
+Once ready to create a new release of his plugin, Karl merges some changes to the `master` branch. 
+At which point, the following takes place under the covers: 
+
+1. A webhook is sent to `{the-webhook-receiver}` by GitHub
+
+2. The receiver forwards this hook to `${trusted-ci-server}`, which is protected by a VPN
+
+3. `${trusted-ci-server}` uses the enhanced version of `buildPlugin` to validate the correctness of 
+Karl's `Autorelease.yaml` file, and the consistency of Karl's chosen version numbering.
+
+4. Once `Autorelease.yaml` has been validated, a plugin build is performed on `${trusted-ci-server}` 
+as one would expect.
+
+5. After the build is successful, `${trusted-ci-server}` handles deployment of the built plugin to 
+Artifactory and the Jenkins Update Center.
+
+=== Detailed Setup
 
 ==== Autorelease.yaml
 
@@ -110,7 +126,7 @@ kind: plugin
 metadata:
   autoreleaseEnabled: true
   triggeringBranch: master
-  appendMergeSHA: true
+  versionNumberFields: 3
 ```
 
 In the above example `Autorelease.yaml`, we can see the following:
@@ -129,15 +145,12 @@ Contains the following fields:
 an autorelease webhook. Although this is expected to usually be set to `master`, plugin 
 maintainers can choose a branch name of their preference, e.g., `autorelease`, `release`, 
 etc.
-** `appendMergeSHA`: A boolean value, indicating whether or not the resultant release will 
-be version numbered including the merge SHA, for example, `2.5.2-1a2b3c4`. This will maintain 
-compatibility with the existing Incrementals versioning.
+** `versionNumberFields`: An integer, indicating the number of fields which `buildPlugin` should expect.
+This is important, because sticking to a consistent numbering scheme makes for easier sorting by version.
+For this example plugin, Karl has set the value to `3`, because he's usuing semantic versioning, e.g., 
+3.1.4.
 
-=== Adoption
-
-To illustrate how this would be used by a plugin maintainer, we'll continue with our fictional example.
-Plugin maintainer Karl has decided that he would like to automatically release fancy-branch-source 
-automatically, each time he merges to a branch called `release-the-fanciness`. 
+==== Maven POM file changes
 
 Karl's plugin is already making use of Incrementals, and the relevant lines of his `pom.xml` file 
 look like:
@@ -176,20 +189,24 @@ look like:
 
 ```
 
-This is all pretty run-of-the-mill stuff for a Jenkins plugin, and is well understood already 
-by Karl and the rest of the plugin maintainer community. To enable autorelease, Karl would 
-create a file at the top level of his repository, called `Autorelease.yaml`:
+No additional changes need to be made to `pom.xml` by Karl, he's good to go.
 
-```
-plugin: fancy-branch-source
-kind: plugin
-metadata:
-  autoreleaseEnabled: true
-  triggeringBranch: release-the-fanciness
-  appendMergeSHA: true
-```
+=== What happens when a release is created
 
-When Karl merges a commit into the `release-the-fanciness` branch, that merge commit has the 
+==== Changes to `buildPlugin`
+
+The commonly used library link:https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy[`buildPlugin`] will need to be modified to check for, and validate, the markerfile, called `Autorelease.yaml`. This 
+markerfile will be the mechanism that tells `${trusted-ci-server}` that this plugin should be automatically 
+released.
+
+Validation will include:
+
+1. The 
+
+If validation of `Autorelease.yaml` fails for any reason, the build is not performed and nothing gets deployed.
+
+
+When Karl merges a commit into the `master` branch, that merge commit has the 
 SHA `1a2b3c4`. The following takes place:
 
 * A webhook is sent to `${trusted-ci-server}`, and a build is performed there. 
@@ -232,7 +249,9 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 
 == Backwards Compatibility
 
-Autorelease introduces no new risks with regard to backwards compatibility or a lack thereof.
+Autorelease introduces no new risks with regard to backwards compatibility of plugins themselves. 
+However, there will be a requirement for plugin maintainers to use a consistent version numbering 
+scheme. Consistent version numbering will prevent problems with sorting versions 
 
 With any plugin upgrade, there are backwards compatibility concerns, and Autorelease is no different 
 in that regard. Without Autorelease, there is still nothing stopping a plugin maintainer from releasing 
@@ -244,7 +263,8 @@ maintainers will see no change at all to the way they do their Jenkins plugin wo
 == Security
 
 Autorelease should make things more secure, because they all come from `${trusted-ci-server}`. Rules 
-can be put in place on `${trusted-ci-server}` which prevent people from doing silly things.
+can be put in place on `${trusted-ci-server}`, which can provide implicit enforcement of the 
+Jenkins infrastructure team's security best practices.
 
 == Infrastructure Requirements
 
@@ -252,12 +272,13 @@ We will need:
 
 1. The webhook. Security implications of this are a bit beyond the scope of this document so far.
 ALSO a receiver for the webhook. This 
-2. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
+2. A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
+behind a VPN
+3. The trusted Jenkins server doing these builds will need to be smart enough to understand the 
 `Autorelease.yaml` file, and act according to its settings 
-3. Probably `buildPlugin` will need some code added to validate the contents of `Autorelease.yaml`. 
-Otherwise there's no telling what people might put in there. This needs to be well-hardened before 
-people start using it.
-4. Perhaps a mechanism by which we can verify the authenticity of incoming build requests. But this should be handled by GitHub repository permissions themselves. In other words, if Janet Plugin has merge rights to `the-janet-plugin`, she has that already today.
+4. `buildPlugin` will need some code added to validate `Autorelease.yaml` for correctness, and 
+build the plugin according to the settings described therein
+5. Perhaps a mechanism by which we can verify the authenticity of incoming build requests. But this should be handled by GitHub repository permissions themselves. In other words, if Janet Plugin has merge rights to `the-janet-plugin`, she has that already today.
 
 == Testing
 
@@ -283,4 +304,13 @@ be made available before this JEP is given
 [[footnote-1]]1. Jenkins World 2017, link:http://bit.ly/2x1lCUZ[Contributor Summit Notes], pp. 11-12
 
 
+
+
+We need to either enforce a fixed number of elements in version numbers,
+OR
+have it confiurable, so that:
+    - More than the spec, gets rejected
+    - Less than the spec, `0` gets appended
+
+We know the problem, fixed length is one approach to fixing it.
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -77,7 +77,7 @@ the Jenkins project
 === Overview
 
 We'll use a short story to illustrate what Autorelease will look like when a plugin maintainer 
-named Karl decides that he wants to perform continuous delivery of his (fictional) Karl-Plugin.
+named Karl decides that he wants to perform continuous delivery of his (fictional) `karl-plugin`.
 
 To do so, Karl will:
 
@@ -308,10 +308,10 @@ something that plugin maintainers need not worry about.
 
 == Infrastructure Requirements
 
-We will need a number of things to get this going. The low level technical details will be described 
+We will need a number of things to get this going. The low-level technical details will be described 
 in a separate Infrastructure Enhancement Request, so, this should be considered a summary for now:
 
-1. The webhook, configured on each participating plugin . Security implications of this are a bit beyond the scope of this document so far.
+1. The webhook, configured on each participating plugin. Security implications of this are a bit beyond the scope of this document so far.
 2. A receiver for the aforementioned webhook, because the `${trusted-ci-server}` will be protected 
 behind a VPN
 3. A trusted Jenkins server for performing builds and deployments. 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -76,7 +76,7 @@ the Jenkins project
 
 === Overview
 
-We'll use a short story to illustrate what Autorelease will look like when a plugin maintainer 
+We'll use a short story to illustrate what it will look like when a plugin maintainer 
 named Karl decides that he wants to perform continuous delivery of his (fictional) `karl-plugin`.
 
 To do so, Karl will:
@@ -191,7 +191,7 @@ look like:
         <jenkins.version>2.138.4</jenkins.version>
     </properties>
 
-```
+----
 
 No additional changes need to be made to `pom.xml` by Karl, he's good to go.
 

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -77,12 +77,12 @@ the Jenkins project
 === Overview
 
 We'll use a short story to illustrate what Autorelease will look like when a plugin maintainer 
-decides that they want to take part.
+named Karl decides that he wants to perform continuous delivery of his Fancy Branch Plugin.
 
-Karl, a plugin developer who owns the fancy-branch-plugin, wants to add CD to his project. To do so, 
-he will:
+To do so, Karl will:
 
-1. Verify support. Karl's plugin is already in the jenkinsci Organization on GitHub, and is 
+1. Verify support. Karl's plugin is already in the 
+link:https://github.com/jenkinsci[jenkinsci Organization on GitHub], and is 
 using `buildPlugin` when built on ci.jenkins.io.
 
 2. Choose a branch from which to release. Karl decides he wants to release from the `master` branch, 
@@ -118,7 +118,8 @@ Artifactory and the Jenkins Update Center.
 A YAML markerfile, stored in the plugin's own repository. Absence of this markerfile will 
 be functionally equivalent to the plugin maintainer opting out of Autorelease. 
 
-In the following example, we'll use a fictional plugin, called `fancy-branch-source`
+In the following example, we'll stick with plugin developer Karl, and his fictional 
+plugin `fancy-branch-source`. Karl's `Autorelease.yaml` file looks like this:
 
 ```
 plugin: fancy-branch-source

--- a/jep/0000/README.adoc
+++ b/jep/0000/README.adoc
@@ -275,19 +275,19 @@ YAML is becoming increasingly common in the Jenkins community, for many reasons.
 * Easily parsed by any number of publicly available libraries
 
 === Webhooks and the Webhook Receiver
-Webhooks will be used to trigger the builds on the trusted CI server. The hooks themselves 
-will be configured on a per-repository basis. The reasons for choosing individual hooks, 
-as opposed to an organization wide hook, are:
+Webhooks will be used to trigger the builds on the trusted CI server. Because this trusted CI 
+server will reside on a non-public network, there needs to be a proxy server of sorts, which 
+can accept these webhooks and send them securely to the trusted CI server.
 
-* Security of the build systems. Because this trusted CI server will reside on a non-public 
-network, there needs to be a proxy server of sorts, which can accept these webhooks and send 
-them, securely, to the trusted CI server.
+The hooks themselves will be configured on a per-repository basis. Per-repository hooks 
+allow for easier traceability. An organization-wide webhook would send those hooks to the 
+receiver far more often than is actually necessary. In the event that something goes wrong 
+with this process - the receiver goes down, there is a network outage, etc. - it will be 
+easier for the Infra team to triage problems if they're only looking at hooks from plugins 
+which are intended to be released via CD.
 
-* Traceability. An organization-wide webhook would send those hooks to the receiver far more 
-often than is actually necessary. In the event that something goes wrong with this process - 
-the receiver goes down, there is a network outage, etc. - it will be easier for the Infra 
-team to triage problems if they're only looking at hooks from plugins which are intended 
-to be released via CD.
+WARNING: The use of per-repository webhooks versus a single, organization-wide hook, is 
+open for discussion. There are good reasons to do it either way.
 
 === Testing Considerations
 Continuous Delivery brings with it a heightened importance for quality automated tests. However, 
@@ -346,7 +346,7 @@ build the plugin according to the settings described therein
 5. Service account(s), managed by the Jenkins Infrastructure team, which provide secure credentials 
 to systems such as Artifactory
 
-CAUTION: TODO: Things such as service accounts and new servers will be handled in a separate IEP.
+WARNING: Things such as service accounts and new servers will be documented in a separate IEP.
 
 == Testing
 

--- a/jep/221/README.adoc
+++ b/jep/221/README.adoc
@@ -1,4 +1,4 @@
-= JEP-0000: Continuous Delivery of Jenkins Plugins
+= JEP-221: Continuous Delivery of Jenkins Plugins
 :toc: preamble
 :toclevels: 3
 ifdef::env-github[]
@@ -13,7 +13,7 @@ endif::[]
 [cols="1h,1"]
 |===
 | JEP
-| 0000
+| 221
 
 | Title
 | Continuous Delivery of Jenkins Plugins
@@ -26,10 +26,10 @@ endif::[]
 | Draft :speech_balloon:
 
 | Type
-| Process :bulb:
+| Process 
 
 | Created
-| :bulb:
+| 2019-07-13
 
 | BDFL-Delegate
 | TBD

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -177,6 +177,11 @@
 | https://github.com/jvz[Matt{nbsp}Sicker]
 | TBD
 
+| Draft{nbsp}:speech_balloon:
+| link:221/README.adoc[JEP-221: Continuous Delivery of Jenkins Plugins]
+| link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
+| TBD
+
 | Accepted{nbsp}:ok_hand:
 | link:300/README.adoc[JEP-300: Jenkins Evergreen]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]


### PR DESCRIPTION
This proposal, once complete, will describe a mechanism by which Jenkins plugin maintainers could choose to have their plugins released upon merging to a particular branch. This merge operation would trigger a webhook, which would in turn trigger a build/test/deploy cycle from a trusted CI server managed by the Jenkins infrastructure team.