### PR TITLE
Marking JEP-305 as Final

### DIFF
--- a/jep/305/README.adoc
+++ b/jep/305/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Final :lock:
 
 | Type
 | Process

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -207,7 +207,7 @@
 | link:https://github.com/batmat[Baptiste{nbsp}Mathus]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]
 
-| Draft{nbsp}:speech_balloon:
+| Final{nbsp}:lock:
 | link:305/README.adoc[JEP-305: Publishing incremental commits as Maven releases]
 | link:https://github.com/jglick[Jesse{nbsp}Glick]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]


### PR DESCRIPTION
Just noticed this was still in Draft status, which is not right—it is long since implemented and in widespread use. (Certainly there are various open RFEs and the like, but that will always be true.)