### PR TITLE
README: Remove the reference to defunct JEP meetings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,8 +24,6 @@ documenting the design decisions that have gone into Jenkins.
 There is also a video of a presentation giving an
 link:https://youtu.be/d7Oy4Qq-Tjw[overview of the JEP Process].
 
-Each week we have Jenkins Enhancement Proposal Office Hours. The time and link to these can be found on https://jenkins.io/event-calendar/.
-
 == License
 
 This repository's contents are considered under the


### PR DESCRIPTION
We do not longer have JEP Meetings, and there is no immediate plan to remove them. I suggest just removing the sentence for now