### PR TITLE
Address JEP-223 feedback

### DIFF
--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -222,9 +222,9 @@ Since the granting of the `Jenkins.CONFIGURE` is optional, administrators who fi
 While we do not anticipate that this change will introduce any regressions, we do acknowledge that some cases may be found after the initial release that may result in confusing or broken behavior for some plugins (ex. a configure link is shown for some plugin, but clicking it results in a permission failure when actually accessing its management link).  
 Because of this, we (the JEP-223 sponsors) are committed to the following support policy:
 
-* For issues raised against Jenkins Core, we will review and fix (or provide justification for not fixing) problems related to this change
-* For issues raised against plugins that are bundled with Jenkins, we will review and fix (or provide justification for not fixing) problems related to this change
-* For issues raised against plugins that are not bundled with Jenkins, we will review and determine the level of impact caused by the regression.  If the issued is determined to create a significant regression we will commit to providing a fix or workaround.
+* For issues raised against Jenkins Core, we will review and fix (or provide justification for not fixing) problems related to this change within 3 months of the LTS release
+* For issues raised against plugins that are installed by default through the setup wizard, we will review and fix (or provide justification for not fixing) problems related to this change within 3 months of the LTS release
+* For issues raised against plugins that are not installed by default through the setup wizard, we will review and determine the level of impact caused by the regression.  If the issued is determined to create a significant regression we will commit to providing a fix or workaround.
 
 [NOTE]
 ====

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -220,10 +220,16 @@ No existing permission types are being removed at this point, which will allow f
 Removing code references to the "dangerous" permissions is outside the scope of this JEP.
 Since the granting of the `Jenkins.CONFIGURE` is optional, administrators who find the new permission does not provide value for them can simply continue to grant `Jenkins.ADMINISTER` to users who need overall administrator access (`Jenkins.CONFIGURE` is implied by `Jenkins.ADMINISTER`).
 While we do not anticipate that this change will introduce any regressions, we do acknowledge that some cases may be found after the initial release that may result in confusing or broken behavior for some plugins (ex. a configure link is shown for some plugin, but clicking it results in a permission failure when actually accessing its management link).  
-Because of this, we are committed to the following support policy:
+Because of this, we (the JEP-223 sponsors) are committed to the following support policy:
+
 * For issues raised against Jenkins Core, we will review and fix (or provide justification for not fixing) problems related to this change
 * For issues raised against plugins that are bundled with Jenkins, we will review and fix (or provide justification for not fixing) problems related to this change
-* For issues raised against plugins that are not bundled with Jenkins, it will be up to the maintainers of those plugins to address any found issues
+* For issues raised against plugins that are not bundled with Jenkins, we will review and determine the level of impact caused by the regression.  If the issued is determined to create a significant regression we will commit to providing a fix or workaround.
+
+[NOTE]
+====
+TBD: The definition of a "serious regression"
+====
 
 == Security
 

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -245,7 +245,7 @@ The prototype code can be found at:
 * link:https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/lThSifB8G4k/HqaHxNoNCgAJ[Should Jenkins.CONFIGURE allow installation of plugins available in Update Center]
 
 === Related efforts
-* link:https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions[SECIRUTY-410 - Matrix Authorization Strategy Plugin allowed configuring dangerous permissions]
+* link:https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions[SECURITY-410 - Matrix Authorization Strategy Plugin allowed configuring dangerous permissions]
 
 * link:https://issues.jenkins-ci.org/browse/JENKINS-60406[Deprecate Jenkins.RUN_SCRIPTS, PluginManager.UPLOAD_PLUGINS, & PluginManager.CONFIGURE_UPDATECENTER]
 ** Parallel effort to officially deprecate (in the code) permissions which effectively equate to `Jenkins.ADMINISTER`

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -78,6 +78,7 @@ This type of permission is a form of "Limited Administer" capability, a term use
 
 Any methods that check for `Jenkins.ADMINISTER`, `Jenkins.RUN_SCRIPTS`, `PluginManager.CONFIGURE_UPDATECENTER`, and `PluginManager.UPLOAD_PLUGINS` will be evaluated to determine if the use of the new `Jenkins.CONFIGURE` permission type is appropriate.
 The general rule of thumb is that configuration items which do not let you change the underlying security model (either directly, or through a malicious plugin or groovy script), or change fundamental configurations such as hostnames, proxy configuration, etc. are likely candidates to use the `Jenkins.CONFIGURE`.
+Plugins that using the deprecated `Plugin#configure` mechanism will not be exposed to users with the `Jenkins.CONFIGURE' permission.
 
 The changes to the existing permissions are detailed in the diagram below. 
 

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -79,6 +79,8 @@ This type of permission is a form of "Limited Administer" capability, a term use
 Any methods that check for `Jenkins.ADMINISTER`, `Jenkins.RUN_SCRIPTS`, `PluginManager.CONFIGURE_UPDATECENTER`, and `PluginManager.UPLOAD_PLUGINS` will be evaluated to determine if the use of the new `Jenkins.CONFIGURE` permission type is appropriate.
 The general rule of thumb is that configuration items which do not let you change the underlying security model (either directly, or through a malicious plugin or groovy script), or change fundamental configurations such as hostnames, proxy configuration, etc. are likely candidates to use the `Jenkins.CONFIGURE`.
 Plugins that using the deprecated `Plugin#configure` mechanism will not be exposed to users with the `Jenkins.CONFIGURE' permission.
+Prior to this change, plugins could assume that, in the abscence of performing an explicit permission check themselves, access would be restricted by default because any top level management links require `Jenkins.ADMINISTER` permission in order to access them.
+To mitigate the risk of a plugin that does not perform an explicit permission check exposing a potentially "dangerous" configuration option, Jenkins will assume by default that the `Jenkins.ADMINISTER` permission is required to render any plugin options exposed via a management page.
 
 The changes to the existing permissions are detailed in the diagram below. 
 

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -204,7 +204,7 @@ Hence, it will not imply any `Job`, `View` or `Agent` level permission.
 About `Jenkins.READ` (a.k.a `Overall Read`, required to access the web or use the CLI), we have decided to *not* imply it for the following reasons:
 
 * To follow the current standard: Every other permission (except `Jenkins.ADMINISTER`) is not implying it. 
-* Technical limitation: the current implementation of `Permission` makes impossible to make `Jenkins.CONFIGURE` imply `Jenkins.READ`, because a permission can not be implied by more than one, and `Jenkins.READ` is already implied by `Permission.READ`. 
+* Technical limitation: the current implementation of `Permission` makes it impossible for `Jenkins.CONFIGURE` to imply `Jenkins.READ`, because a permission can not be implied by more than one, and `Jenkins.READ` is already implied by `Permission.READ`. 
 
 image::CONFIGURE-and-READ-permissions.svg[]
 

--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -218,6 +218,12 @@ For the most current discussions on these points (and more) please refer to link
 
 No existing permission types are being removed at this point, which will allow for existing plugins that make use of them to continue to function.
 Removing code references to the "dangerous" permissions is outside the scope of this JEP.
+Since the granting of the `Jenkins.CONFIGURE` is optional, administrators who find the new permission does not provide value for them can simply continue to grant `Jenkins.ADMINISTER` to users who need overall administrator access (`Jenkins.CONFIGURE` is implied by `Jenkins.ADMINISTER`).
+While we do not anticipate that this change will introduce any regressions, we do acknowledge that some cases may be found after the initial release that may result in confusing or broken behavior for some plugins (ex. a configure link is shown for some plugin, but clicking it results in a permission failure when actually accessing its management link).  
+Because of this, we are committed to the following support policy:
+* For issues raised against Jenkins Core, we will review and fix (or provide justification for not fixing) problems related to this change
+* For issues raised against plugins that are bundled with Jenkins, we will review and fix (or provide justification for not fixing) problems related to this change
+* For issues raised against plugins that are not bundled with Jenkins, it will be up to the maintainers of those plugins to address any found issues
 
 == Security
 


### PR DESCRIPTION
This PR addresses the following feedback from @daniel-beck and @jvz :

- This is a fairly complex change with no commitment to address regressions (like JEP-200 did). 
- If there are still plugins using the deprecated Plugin#configure  mechanism, their configuration appears to be always hidden from Jenkins/Configure via GlobalPluginConfiguration#configure . We're probably good with that?

> Plugins that contribute to the settings on on the Configure Jenkins page should carefully consider if allowing a user with only Jenkins.CONFIGURE could result in an unintended privelege escalation.

- This sounds like a fairly onerous requirement for plugins. Based on the numerous published security advisories just around plugins not bothering with a permission check in the first place, this sounds like a fairly large hole. How could we mitigate that?

