### PR TITLE
[JEP-4, JEP-10, JEP-13] - Mark SIG, Twitter and YouTube JEPs as active

### DIFF
--- a/jep/10/README.adoc
+++ b/jep/10/README.adoc
@@ -22,7 +22,7 @@ endif::[]
 | link:https://github.com/tracymiranda[Tracy Miranda]
 
 | Status
-| Draft :speech_balloon:
+| Active :smile:
 
 | Type
 | Process

--- a/jep/13/README.adoc
+++ b/jep/13/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Active :smile:
 
 | Type
 | Process

--- a/jep/4/README.adoc
+++ b/jep/4/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Active :smile:
 
 | Type
 | Process

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -22,7 +22,7 @@
 | link:https://github.com/oleg-nenashev[Oleg{nbsp}Nenashev]
 | _not{nbsp}delegated_
 
-| Draft{nbsp}:speech_balloon:
+| Active{nbsp}:smile:
 | link:4/README.adoc[JEP-4: Special Interest Groups]
 | link:https://github.com/rtyler[R{nbsp}Tyler{nbsp}Croy]
 | _not{nbsp}delegated_
@@ -52,7 +52,7 @@
 | link:https://github.com/kohsuke[Kohsuke{nbsp}Kawaguchi]
 | _not{nbsp}delegated_
 
-| Draft{nbsp}:speech_balloon:
+| Active{nbsp}:smile:
 | link:10/README.adoc[JEP-10: Jenkins Twitter Policy for Contributors]
 | link:https://github.com/tracymiranda[Tracy{nbsp}Miranda]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]
@@ -67,7 +67,7 @@
 | link:https://github.com/tracymiranda[Tracy{nbsp}Miranda]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]
 
-| Draft{nbsp}:speech_balloon:
+| Active{nbsp}:smile:
 | link:13/README.adoc[JEP-13: Jenkins YouTube Channel Policy for Contributors]
 | link:https://github.com/oleg-nenashev[Oleg{nbsp}Nenashev]
 | link:https://github.com/bitwiseman[Liam{nbsp}Newman]
@@ -188,7 +188,7 @@
 | TBD
 
 | Draft{nbsp}:speech_balloon:
-| link:223/README.adoc[JEP-223: "Limited Administer" permission for managing non-security aspects of a Jenkins instance]
+| link:223/README.adoc[JEP-223: "Manage" permission for managing non-security aspects of a Jenkins instance]
 | link:https://github.com/mikecirioli[Mike{nbsp}Cirioli], link:https://github.com/aHenryJard[Angélique{nbsp}Jard], link:https://github.com/EstherAF[Esther{nbsp}Álvarez{nbsp}Feijoo] 
 | TBD
 


### PR DESCRIPTION
We are actively using JEPs for SIGs, Twitter and YouTube in the community's day-to-day work. And they work pretty well. These are the process JEPs, and hence they can be adjusted later if needed. So I would suggest to mark these JEPs as active.

This change requires approvals from @rtyler and @bitwiseman who were assigned as BDFL delegates