### PR TITLE
Assign BDFL delegates to JEP-14, JEP-218, JEP-220 and JEP-224

### DIFF
--- a/jep/14/README.adoc
+++ b/jep/14/README.adoc
@@ -32,7 +32,7 @@ endif::[]
 | 2020-03-27
 
 | BDFL-Delegate
-| TBD
+| link:https://github.com/slide[Alex Earl]
 
 //
 // Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.

--- a/jep/218/README.adoc
+++ b/jep/218/README.adoc
@@ -32,7 +32,7 @@ endif::[]
 | 2018-08-21
 
 | BDFL-Delegate
-| TBD
+| link:https://github.com/daniel-beck[Daniel Beck]
 
 //
 //

--- a/jep/220/README.adoc
+++ b/jep/220/README.adoc
@@ -33,7 +33,7 @@ endif::[]
 | 2019-07-17
 
 | BDFL-Delegate
-| TBD
+| link:https://github.com/daniel-beck[Daniel Beck]
 
 //
 //

--- a/jep/224/README.adoc
+++ b/jep/224/README.adoc
@@ -32,7 +32,7 @@ endif::[]
 | 2020-01-20
 
 | BDFL-Delegate
-| TBD
+| link:https://github.com/oleg-nenashev[Oleg Nenashev]
 
 //
 //

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -75,7 +75,7 @@
 | Draft{nbsp}:speech_balloon:
 | link:14/README.adoc[JEP-14: Public roadmap for major initiatives in the Jenkins project]
 | link:https://github.com/oleg-nenashev[Oleg{nbsp}Nenashev]
-| TBD
+| link:https://github.com/slide[Alex{nbsp}Earl]
 
 | Final{nbsp}:lock:
 | link:200/README.adoc[JEP-200: Switch Remoting/XStream blacklist to a whitelist]
@@ -170,7 +170,7 @@
 | Draft{nbsp}:speech_balloon:
 | link:218/README.adoc[JEP-218: Stapler Request Dispatcher Filtering]
 | link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
-| TBD
+| link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
 
 | Draft{nbsp}:speech_balloon:
 | link:219/README.adoc[JEP-219: Jenkins Kubernetes Operator]
@@ -180,7 +180,7 @@
 | Draft{nbsp}:speech_balloon:
 | link:220/README.adoc[JEP-220: Dispatchable Views and View Fragments in Stapler]
 | https://github.com/jvz[Matt{nbsp}Sicker]
-| TBD
+| link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
 
 | Draft{nbsp}:speech_balloon:
 | link:221/README.adoc[JEP-221: Continuous Delivery of Jenkins Plugins]
@@ -200,7 +200,7 @@
 | Draft{nbsp}:speech_balloon:
 | link:224/README.adoc[JEP-224: Readonly system configuration]
 | link:https://github.com/timja[Tim{nbsp}Jacomb]
-| TBD
+| link:https://github.com/oleg-nenashev[Oleg{nbsp}Nenashev]
 
 | Accepted{nbsp}:ok_hand:
 | link:300/README.adoc[JEP-300: Jenkins Evergreen]


### PR DESCRIPTION
As discussed with @slide @daniel-beck, I suggest them as BDFL delegates for JEP-14, JEP-218, JEP-220. I would also like to beome a BDFL delegate for JEP-224 as discussed with @timja. Ultimately this PR needs sign-off/merge by @kohsuke to become valid according to our JEP process