### PR TITLE
Mark JEP-12 "Travel grant program" as active

### DIFF
--- a/jep/12/README.adoc
+++ b/jep/12/README.adoc
@@ -22,7 +22,7 @@ endif::[]
 | link:https://github.com/tracymiranda[Tracy Miranda]
 
 | Status
-| Draft :speech_balloon:
+| Active :smile:
 
 | Type
 | Process

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -62,7 +62,7 @@
 | link:https://github.com/rodrigc[Craig{nbsp}Rodrigues]
 | TBD
 
-| Draft{nbsp}:speech_balloon:
+| Active{nbsp}:smile:
 | link:12/README.adoc[JEP-12: Travel Grant Program]
 | link:https://github.com/tracymiranda[Tracy{nbsp}Miranda]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]


### PR DESCRIPTION
I am doing a cleanup of draft JEPs, and this one is pretty important because of the [Funding rework](https://groups.google.com/forum/#!msg/jenkinsci-dev/iLutO2X0bdg/qcEpxS1iBgAJ) I am doing in the background. This process JEP is well-written and covers main items, so I would propose to call it an active one.

Later we may need to move bits from JEP-8 about using travel budget into this JEP: https://github.com/jenkinsci/jep/tree/master/jep/8#using-the-budget . If @tracymiranda prefers to have it done first, I will mighrate the content.
