### PR TITLE
[JEP-223] Using Epic JIRA instead of the first PR Jira

### DIFF
--- a/jep/223/README.adoc
+++ b/jep/223/README.adoc
@@ -41,7 +41,7 @@ endif::[]
 //
 // Uncomment if there is an associated placeholder JIRA issue.
 | JIRA
-| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-60266[JENKINS-60266] :bulb:
+| :bulb: https://issues.jenkins-ci.org/browse/JENKINS-61454[JENKINS-61454] :bulb:
 //
 //
 // Uncomment if discussion will occur in forum other than jenkinsci-dev@ mailing list.


### PR DESCRIPTION
To be more complete and accurate about the JEP, it seems better to use the EPIC link as Jira link.