### PR TITLE
[JEP-226] Improve section on fingerprint cleanup

### DIFF
--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -122,12 +122,22 @@ For an external storage implementation, this creates a problem because the exter
 
 This proposal offers the following solution:
 
-* When a build/job is deleted from Jenkins, a subsequent update is performed to the fingerprint to reflect this change
 * An async periodic work is run to check if any fingerprint has no jobs/builds associated with it and delete it. (But, it would ensure that if there is a deletion blocking `FingerprintFacet`, then the fingerprint would not be deleted.)
 
-The above solution is provided to the user as an option, and can be toggled because it may be the case that storing data (i.e. fingerprints) might be cheaper than to do consistent updates in the database.
+New methods to be introduced inside the `FingerprintStorage` class:
 
-We do not propose to revamp the `FingerprintCleanupThread` to use the above logic at the moment.
+* `void setFingerprintCleanupThread(boolean toggle, @CheckForNull how_often_to_run_it)`
+
+** FingerprintCleanupThread can be enabled or disabled. External storages can use this method. We can set the trigger interval also here.
+
+* `List<String> getAllFingerprintIds()`
+
+** Returns all the fingerprint ids currently stored by the particular Jenkins instance.
+
+We propose to revamp the `FingerprintCleanupThread` to use the new API.
+The new `FingerprintCleanupThread` will use `FingerprintStorage#getAllFingerprintIds()` to obtain the list of fingerprints to check. If all the associated builds to a fingerprint have been deleted, `FingerprintStorage#delete(String id)` will be called in order to delete the fingerprint.
+
+The above solution is provided to the user as an option, and can be toggled because it may be the case that storing data (i.e. fingerprints) might be cheaper than to do consistent updates in the database.
 
 ==== External to Local Migration (out of scope for MVP)
 

--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -124,7 +124,7 @@ This proposal offers the following solution:
 
 * An async periodic work is run to check if any fingerprint has no jobs/builds associated with it and delete it. (But, it would ensure that if there is a deletion blocking `FingerprintFacet`, then the fingerprint would not be deleted.)
 
-New methods to be introduced inside the `FingerprintStorage` class:
+New methods introduced inside the `FingerprintStorage` class:
 
 * `void setFingerprintCleanupThread(boolean toggle, @CheckForNull how_often_to_run_it)`
 
@@ -134,8 +134,8 @@ New methods to be introduced inside the `FingerprintStorage` class:
 
 ** Returns all the fingerprint ids currently stored by the particular Jenkins instance.
 
-We propose to revamp the `FingerprintCleanupThread` to use the new API.
-The new `FingerprintCleanupThread` will use `FingerprintStorage#getAllFingerprintIds()` to obtain the list of fingerprints to check. If all the associated builds to a fingerprint have been deleted, `FingerprintStorage#delete(String id)` will be called in order to delete the fingerprint.
+`FingerprintCleanupThread` is revamped to use the new API.
+The new `FingerprintCleanupThread` uses `FingerprintStorage#getAllFingerprintIds()` to obtain the list of fingerprints to check. If all the associated builds to a fingerprint have been deleted, `FingerprintStorage#delete(String id)` is called in order to delete the fingerprint.
 
 The above solution is provided to the user as an option, and can be toggled because it may be the case that storing data (i.e. fingerprints) might be cheaper than to do consistent updates in the database.
 

--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -116,31 +116,26 @@ This by followed by clearing the local database of fingerprints from Jenkins HOM
 
 ==== Cleaning up Fingerprints
 
-The current implementation of `FingerprintCleanupThread` works by periodically iterating over the fingerprints and deleting the ones whose builds and jobs are no longer present in the system.
+The current implementation of `FingerprintCleanupThread` works by periodically iterating over the fingerprints and
+editing the job and build information of the ones based on whether they are still present in the system. It also
+deletes the fingerprints which do not have any build or job associated with them.
 
-For an external storage implementation, this creates a problem because the external storage cannot query a Jenkins instance.
+We extend this fingerprint cleanup functionality to be supported by external storages. `FingerprintStorage` API is
+extended with the following methods:
 
-This proposal offers the following solution:
+* `iterateAndCleanupFingerprints(TaskListener taskListener)`
 
-* An async periodic work is run to check if any fingerprint has no jobs/builds associated with it and delete it. (But, it would ensure that if there is a deletion blocking `FingerprintFacet`, then the fingerprint would not be deleted.)
+** Plugins can implement this method (which is called by Jenkins core periodically) to iterate and cleanup the
+fingerprints. The reason to design it this way, and not to iterate all the fingerprints via core, is because
+external storages may be able to implement more efficient traversal strategies on their own.
 
-New methods introduced inside the `FingerprintStorage` class:
+* `boolean cleanFingerprint(Fingerprint fingerprint, TaskListener taskListener)`
 
-* `void setFingerprintCleanupThread(boolean toggle, @CheckForNull int recurrence_period)`
+** This provides a reference implementation of cleanup, which external storages can use to cleanup a fingerprint.
+They may use this, or extend it to provide custom implementations.
 
-** FingerprintCleanupThread can be enabled or disabled (true is ON, false is OFF). External storages can use this method. `recurrence_period` is time in milliseconds.
-
-* `List<String> getAllFingerprintIds()`
-
-** Returns all the fingerprint ids currently stored by the particular Jenkins instance.
-
-How the new fingerprint cleanup process now runs:
-
-* There will be a default implementation of fingerprint cleanup (albeit inefficient) which fetches all the fingerprint ids using `FingerprintStorage#getAllFingerprintIds()` and deletes them if they are qualified to be discarded.
-
-* Plugins can overwrite the above implementation to provide more efficient implementations which may use database specific features (e.g. pointers) to offer the cleanup facility.
-
-The above solution is provided to the user as an option, and can be toggled because it may be the case that storing data (i.e. fingerprints) might be cheaper than to do consistent updates in the database.
+Finally, we introduce the option to turn off fingerprint cleanup. This is done because it may be the case that storing
+extra data may be cheaper than performing cleanups, especially with external storages.
 
 ==== External to Local Migration (out of scope for MVP)
 

--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -126,9 +126,9 @@ This proposal offers the following solution:
 
 New methods introduced inside the `FingerprintStorage` class:
 
-* `void setFingerprintCleanupThread(boolean toggle, @CheckForNull how_often_to_run_it)`
+* `void setFingerprintCleanupThread(boolean toggle, @CheckForNull int recurrence_period)`
 
-** FingerprintCleanupThread can be enabled or disabled (true is ON, false is OFF). External storages can use this method. We can set the trigger interval also here.
+** FingerprintCleanupThread can be enabled or disabled (true is ON, false is OFF). External storages can use this method. `recurrence_period` is time in milliseconds.
 
 * `List<String> getAllFingerprintIds()`
 

--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -134,8 +134,11 @@ New methods introduced inside the `FingerprintStorage` class:
 
 ** Returns all the fingerprint ids currently stored by the particular Jenkins instance.
 
-`FingerprintCleanupThread` is revamped to use the new API.
-The new `FingerprintCleanupThread` uses `FingerprintStorage#getAllFingerprintIds()` to obtain the list of fingerprints to check. If all the associated builds to a fingerprint have been deleted, `FingerprintStorage#delete(String id)` is called in order to delete the fingerprint.
+How the new fingerprint cleanup process now runs:
+
+* There will be a default implementation of fingerprint cleanup (albeit inefficient) which fetches all the fingerprint ids using `FingerprintStorage#getAllFingerprintIds()` and deletes them if they are qualified to be discarded.
+
+* Plugins can overwrite the above implementation to provide more efficient implementations which may use database specific features (e.g. pointers) to offer the cleanup facility.
 
 The above solution is provided to the user as an option, and can be toggled because it may be the case that storing data (i.e. fingerprints) might be cheaper than to do consistent updates in the database.
 

--- a/jep/226/README.adoc
+++ b/jep/226/README.adoc
@@ -128,7 +128,7 @@ New methods introduced inside the `FingerprintStorage` class:
 
 * `void setFingerprintCleanupThread(boolean toggle, @CheckForNull how_often_to_run_it)`
 
-** FingerprintCleanupThread can be enabled or disabled. External storages can use this method. We can set the trigger interval also here.
+** FingerprintCleanupThread can be enabled or disabled (true is ON, false is OFF). External storages can use this method. We can set the trigger interval also here.
 
 * `List<String> getAllFingerprintIds()`
 


### PR DESCRIPTION
Why am I doing this? I now realise that it does not make sense to keep the build pointers to a fingerprint updated if we have to run a periodic job anyway. Might as well use it to update the build pointers, just like the current implementation does it.

I have also proposed revamping the current fingerprint cleanup to use the new API, so it becomes homogenous.

@oleg-nenashev @afalko @mikecirioli  Would love to hear your thoughts, as this is highly important for the next steps :)