### PR TITLE
Removing jenkins-cloudfoundry-uaa

### DIFF
--- a/jep/227/compatibility.adoc
+++ b/jep/227/compatibility.adoc
@@ -142,10 +142,6 @@ would need to be adjusted to make tests pass.
 |Probably compatible
 |Untested.
 
-|link:https://plugins.jenkins.io/jenkins-cloudfoundry-uaa/[jenkins-cloudfoundry-uaa]
-|Incompatible
-|Uses `BeanBuilder` and possibly other problematic types.
-
 |link:https://plugins.jenkins.io/jobConfigHistory/[jobConfigHistory]
 |Probably compatible
 |Pending link:https://github.com/jenkinsci/jobConfigHistory-plugin/pull/127[jobConfigHistory-plugin #127] for test passing and ensuring full compatibility when users are lacking permissions.


### PR DESCRIPTION
In https://github.com/jenkinsci/jep/pull/295#discussion_r495468593 @daniel-beck points out that no such plugin exists on the update center.
Seems to have been a CloudBees proprietary plugin.
