### PR TITLE
[JEP-227] Links to japicmp report will be dead

### DIFF
--- a/jep/227/README.adoc
+++ b/jep/227/README.adoc
@@ -92,7 +92,7 @@ In mostly chronological order, though of course many tasks can be parallelized:
 ** `ldap` needs extensive work.
 * Run acceptance tests (ATH) and plugin compatibility tests (PCT) against core plus a representative subset of plugins.
 * Interactively verify that core plus all plugins mentioned in the setup wizard (even if not `suggested`) seem to work.
-* Evaluate the link:https://ci.jenkins.io/job/Core/job/jenkins/job/PR-4848/API_20compatibility/japicmp.html[japicmp report for Jenkins core] to make sure that all incompatible as well as compatible API changes are expected.
+* Evaluate the japicmp report for Jenkins core to make sure that all incompatible as well as compatible API changes are expected.
 * Solicit code reviews on all open associated pull requests to core and plugins.
 * Create a compatibility chart associated with this JEP listing all known plugins that might be affected by this change, with their current status.
 * Define a Jira label for regressions suspected to be related to this migration,
@@ -383,8 +383,6 @@ producing a much shorter report.
 Some matches are from plugins which already have preparatory patches.
 A number of the remaining matches are Spring types that are _probably_ compatible from 2.x to 5.x.
 
-You can also check the link:https://ci.jenkins.io/job/Core/job/jenkins/job/PR-4848/API_20compatibility/japicmp.html[japicmp report for Jenkins core].
-
 == Security
 
 This JEP changes Jenkins code fundamental to security and so introduces inherent security risks.
@@ -420,8 +418,6 @@ CloudBees is running the ATH & PCT against patched Jenkins core and many popular
 ** link:https://github.com/jenkinsci/jenkins/pull/4848[jenkins #4848] (upgrade to Spring Security 5 by jglick)
 * Tracking
 ** link:compatibility.adoc[Compatibility table]
-* Generated reports
-** link:https://ci.jenkins.io/job/Core/job/jenkins/job/PR-4848/API_20compatibility/japicmp.html[japicmp report for Jenkins core]
 * Searching for usages of Acegi Security in plugins
 ** link:https://github.com/jenkins-infra/usage-in-plugins/pull/15[usage-in-plugins #15] (PoC by Wadeck)
 ** link:https://github.com/jenkins-infra/usage-in-plugins/pull/16[usage-in-plugins #16] (general improvement by jglick)


### PR DESCRIPTION
Now that https://github.com/jenkinsci/jenkins/pull/4848 has been merged :tada: the japicmp reports from the PR build may break, depending on the orphaned item strategy, and there is no particular replacement other than the report for the `master` branch build in which the merge occurs, which will also be rotated out of history at some point. (Maybe in the future we should do something with the Checks API?)