### PR TITLE
Marking JEP-227 & JEP-228 accepted

### DIFF
--- a/jep/227/README.adoc
+++ b/jep/227/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Accepted :ok_hand:
 
 | Type
 | Standards

--- a/jep/228/README.adoc
+++ b/jep/228/README.adoc
@@ -25,7 +25,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Accepted :ok_hand:
 
 | Type
 | Standards

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -212,12 +212,12 @@
 | link:https://github.com/stellargo[Sumit{nbsp}Sarin]
 | -
 
-| Draft{nbsp}:speech_balloon:
+| Accepted{nbsp}:ok_hand:
 | link:227/README.adoc[JEP-227: Replace Acegi Security with Spring Security & upgrade Spring Framework]
 | link:https://github.com/jglick[Jesse{nbsp}Glick]
 | TBD
 
-| Draft{nbsp}:speech_balloon:
+| Accepted{nbsp}:ok_hand:
 | link:228/README.adoc[JEP-228: Unforking XStream]
 | link:https://github.com/jglick[Jesse{nbsp}Glick]
 | TBD


### PR DESCRIPTION
I do not think we have any working formal definition of “accepted” after the loss of a BDFL but having the core PRs released as 2.266 seems the closest we can come.
