### PR TITLE
Update JEP-228 compatibility for sonarqube-plugin

### DIFF
--- a/jep/228/compatibility.adoc
+++ b/jep/228/compatibility.adoc
@@ -173,9 +173,8 @@ should be fixed.
 should be fixed.
 
 |link:https://plugins.jenkins.io/sonar/[sonar]
-|Mostly compatible
-|link:https://github.com/jenkinsci/sonarqube-plugin/pull/10[sonarqube-plugin #10]
-should improve compatibility.
+|Compatible
+|As of link:https://github.com/jenkinsci/sonarqube-plugin/releases/tag/sonar-2.13[2.13].
 
 |link:https://plugins.jenkins.io/ssh2easy/[ssh2easy]
 |Incompatible, fixes prepared


### PR DESCRIPTION
This PR updates the JEP-228 compatibility table for sonarqube-plugin, as mentioned on https://github.com/SonarSource/sonar-scanner-jenkins/pull/171