### PR TITLE
[JEP-228] Noting `envinject-api` fix

### DIFF
--- a/jep/228/compatibility.adoc
+++ b/jep/228/compatibility.adoc
@@ -77,9 +77,9 @@ should improve compatibility.
 |Compatible
 |As of link:https://github.com/jenkinsci/email-ext-plugin/releases/tag/email-ext-2.78[2.78].
 
-|link:https://plugins.jenkins.io/envinject/[envinject]
-|Incompatible, fixes prepared
-|Pending link:https://github.com/jenkinsci/envinject-lib/pull/19[envinject-lib #19] and integration into `envinject-api-plugin`.
+|link:https://plugins.jenkins.io/envinject-api/[envinject-api]
+|Compatible
+|As of link:https://github.com/jenkinsci/envinject-api-plugin/releases/tag/envinject-api-1.8[1.8].
 
 |link:https://plugins.jenkins.io/exam/[exam]
 |Mostly compatible


### PR DESCRIPTION
Follows up #378 to note https://github.com/jenkinsci/envinject-api-plugin/pull/17.