### PR TITLE
Final(ish) JEP-235 telemetry results

### DIFF
--- a/jep/235/README.adoc
+++ b/jep/235/README.adoc
@@ -330,6 +330,13 @@ The following plugins have been identified as incompatible with this proposal:
 | TBD
 | Resolved by updating to version 5.2.0 (June 2019) or newer
 
+// weconlogparser is not a public plugin
+
+| https://plugins.jenkins.io/wildfly-deployer/[Wildfly Deployer]
+| TBD
+| TBD
+| n/a (Already broken by https://www.jenkins.io/doc/upgrade-guide/2.303/#SECURITY-2458[security hardening in 2.319 and LTS 2.303.3])
+
 | https://plugins.jenkins.io/xunit/[XUnit] (2.0.2 or older)
 | TBD
 | TBD

--- a/jep/235/check-telemetry.sh
+++ b/jep/235/check-telemetry.sh
@@ -7,6 +7,7 @@ TESTS=(
     'io[.]jenkins[.]plugins[.]coverage[.]source[.]DefaultSourceFileResolver[$]SourceFilePainter[.]paintSourceCode'
     'org[.]jenkinsci[.]plugins[.]genexus[.]server[.]CreateLogTask[.]invoke'
     'com[.]microfocus[.]application[.]automation[.]tools[.]octane[.]tests[.]junit[.]JUnitExtension[$]GetJUnitTestResults[.]invoke'
+    'com[.]hpe[.]application[.]automation[.]tools[.]octane[.]tests[.]junit[.]JUnitExtension[$]GetJUnitTestResults[.]invoke'
     'jenkins[.]plugins[.]itemstorage[.]local[.]LocalObjectPath[$]IsNotThereOrOlderVisitor[.]visit'
     'hudson[.]plugins[.]logparser[.]LogParserStatusComputer[.]computeStatusMatches'
     'hudson[.]maven[.]MavenBuildProxy2[$]Filter[.](start|end)'
@@ -17,6 +18,8 @@ TESTS=(
     'hudson[.]plugins[.]selenium[.]callables[.]SeleniumCallable[.]invoke'
     'hudson[.]plugins[.]violations[.]generate[.]ExecuteFilePath[.]execute'
     'io[.]jenkins[.]plugins[.]analysis[.]core[.]steps[.]IssuesScanner[$]ReportPostProcessor[.]copyAffectedFiles' # until 5.1.0 / before d597cbdb, superseded June 2019
+    'hudson[.]plugins[.]webconlogparser[.]LogParserStatusComputer[.]computeStatusMatches' # Private plugin forked from logparser?
+    'org[.]jenkinsci[.]plugins[.]wildfly[.]WildflyBuilder[$]GrabWARFile[.]invoke'
     'org[.]jenkinsci[.]plugins[.]xunit[.]service[.]XUnitTransformer[.]invoke' # until 2.0.2, superseded June 2018
 )
 RESULTS=(
@@ -25,6 +28,7 @@ RESULTS=(
     'code-coverage-api'
     'genexus'
     'hp-application-automation-tools-plugin'
+    'hp-application-automation-tools-plugin-5.3'
     'jobcacher'
     'log-parser'
     'maven-plugin$MavenBuildProxy2'
@@ -35,6 +39,8 @@ RESULTS=(
     'selenium'
     'violations'
     'warnings-ng-5.1.0'
+    'webconlogparser'
+    'wildfly'
     'xunit-2.0.2'
 )
 


### PR DESCRIPTION
<details>
<summary>Telemetry up to and including most of March 3 (some stragglers)</summary>

```
[REPORTING STATS]
Instances reporting FilePath telemetry:
  254903
Instances reporting non-empty FilePath telemetry:
    1245
[PLUGIN POPULARITY STATS]
Instances reporting each of the known kinds of agent-to-controller FilePath calls:
 577 maven-plugin$MavenBuildProxy2
 294 log-parser
 155 cobertura
 113 publish-over-ssh
  35 violations
  28 maven-plugin$MavenSiteArchiver
  22 hp-application-automation-tools-plugin
  17 selenium
  14 code-coverage-api
  11 maven-plugin$AbstractMavenJavadocArchiver
  10 jobcacher
   6 analysis-core
   3 xunit-2.0.2
   2 warnings-ng-5.1.0
   2 genexus
   1 wildfly
   1 webconlogparser
   1 hp-application-automation-tools-plugin-5.3
   1 ScriptConsole
```

</details>

Three new hits with just one more day to go:

* [Wildfly Deployer](https://plugins.jenkins.io/wildfly-deployer/)
* An old version of [Micro Focus Application Automation Tools](https://plugins.jenkins.io/hp-application-automation-tools-plugin/) with a different package name.
* A private plugin apparently forked from `logparser`.