### PR TITLE
Replace mirrors.jenkins.io with get.jenkins.io

### DIFF
--- a/jep/307/README.adoc
+++ b/jep/307/README.adoc
@@ -358,7 +358,7 @@ core:
   # The URL referenced doesn't need to be sourced through a CDN, Artifactory is
   # suitable. Future versions of the Evergreen backend will need to point to a
   # CDN automatically anyways.
-  urL: 'http://mirrors.jenkins.io/war/latest/jenkins.war'
+  urL: 'https://get.jenkins.io/war/latest/jenkins.war'
   # The checksum is important for the Evergreen backend services, and client,
   # to verify the artifact but also to distinguish effectively between two
   # files which might be referenced in multiple ingest manifests which are in


### PR DESCRIPTION
## Replace mirrors.jenkins.io with get.jenkins.io

The http based mirrors have been replaced with https

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
