### PR TITLE
[JENKINS-51820] Java Web Start support has already been removed

### DIFF
--- a/jep/230/README.adoc
+++ b/jep/230/README.adoc
@@ -76,9 +76,6 @@ It is updated to Apache SSH 2.x.
 `ssh-cli-auth` is inlined into the same plugin.
 Popular plugins (notable `git-server`) can again be given a regular plugin dependency on `sshd`.
 
-`slave-installer` is converted from a module to a plugin (_not_ detached).
-The four installer implementations are inlined into the same plugin.
-
 === Cleanup options
 
 As another cleanup step, `workflow-cps-global-lib` can be given a dependency on `git-server` and thus `sshd` for its original Git-based design,
@@ -87,8 +84,6 @@ split into a new plugin such as `pipeline-libraries` without this dependency.
 
 The `jenkins-module` packaging could be removed from `maven-hpi-plugin`, if there are no other users.
 (Theoretically some vendors could be using it for a `ConfidentialStore` implementation, for example.)
-
-The core classes in the `jenkins.slaves.restarter` package could be moved to the `slave-installer` plugin.
 
 == Motivation
 
@@ -168,33 +163,12 @@ As of the removal of Remoting-based CLI,
 with no independent functionality.
 Therefore there is no advantage in offering it as a separate plugin.
 
-=== Marking `slave-installer` as detached
-
-There is no real likelihood that other plugins would depend on the original extension point or its implementations,
-so treating it as detached would merely add spurious dependencies from numerous plugins,
-making it more difficult to uninstall.
-
-Thes resulting plugin can be considered more or less deprecated,
-since it is only useful when running an inbound agent using the JNLP GUI launcher,
-which is probably unusual in modern environments and does not even work on Java 11.
-Those users who actually want this functionality can install the plugin,
-and it could be mentioned in the setup wizard,
-but it need not be part of the recommended list.
-The functionality imposes a small cost on every agent connection, so it is not free to enable.
-
-For similar reasons, it is simpler to package all this functionality into one plugin,
-rather than litter the plugin list with five plugins,
-most of them containing just a single class.
-(Only the Windows installer—by far the most popular—contains any external dependency, on `winsw`.)
-
 == Backwards Compatibility
 
 The use of the detached plugin mechanism should assure that plugins formerly depending on functionality here,
 namely in `instance-identity` and `sshd`,
 continue to run.
 Users upgrading Jenkins past the change will see these now-detached plugins installed automatically.
-
-Installations actually requiring use of agent installers should explicitly install the new plugin.
 
 Non-GUI installations of Jenkins may need to add `instance-identity` to the plugin set in order for TCP inbound agents to work.
 Similarly, they would need to add `sshd` to the plugin set in order to enable SSH service for the Jenkins CLI.
@@ -213,9 +187,6 @@ Various scenarios involving affected code need to be tested either manually or i
 `JenkinsRule` tests are inadequate since the nature of the changes involves class loading,
 which `JenkinsRule` bypasses.
 
-link:https://github.com/jenkinsci/systemd-slave-installer-module#testing[These tips]
-can be used to test behavior of one agent installer.
-
 == Prototype Implementation
 
 * link:https://github.com/jenkinsci/jenkins/pull/3988[jenkins #3988]
@@ -224,16 +195,10 @@ can be used to test behavior of one agent installer.
 * link:https://github.com/jenkinsci/ssh-cli-auth-module/pull/9[ssh-cli-auth-module #9]
 * link:https://github.com/jenkinsci/sshd-module/pull/29[sshd-module #29]
 * link:https://github.com/jenkinsci/sshd-module/pull/38[sshd-module #38]
-* link:https://github.com/jenkinsci/slave-installer-module/pull/5[slave-installer-module #5]
-* link:https://github.com/jenkinsci/windows-slave-installer-module/pull/24[windows-slave-installer-module #24]
-* link:https://github.com/jenkinsci/launchd-slave-installer-module/pull/3[launchd-slave-installer-module #3]
-* link:https://github.com/jenkinsci/upstart-slave-installer-module/pull/2[upstart-slave-installer-module #2]
-* link:https://github.com/jenkinsci/systemd-slave-installer-module/pull/3[systemd-slave-installer-module #3]
 
 As of this writing, the preceding pull requests need to be reworked to reflect design changes:
 * Simplifying the core patch to reflect changes already incorporated separately.
 * Coalescing some plugins.
-* Removing agent installer functionality from the detached list.
 * Switching to Apache SSH 2.
 
 == References

--- a/jep/236/README.adoc
+++ b/jep/236/README.adoc
@@ -135,7 +135,7 @@ Work to be considered is defined in link:https://issues.jenkins.io/browse/JENKIN
 
 * The link:https://issues.jenkins.io/browse/JENKINS-67688[JENKINS-67688 epic] will include library updates as needed.
 * Some updates may require downstream plugin updates.
-* JavaWS support to be removed from remoting - link:https://github.com/jenkinsci/remoting/pull/507#issuecomment-1030629619[jenkinsci/remoting#507]
+* Java Web Start support to be removed from Remoting: https://github.com/jenkinsci/jenkins/pull/6543[jenkins #6543]
 
 ==== Core patches
 


### PR DESCRIPTION
Updating a couple of JEPs to reflect https://github.com/jenkinsci/jenkins/pull/6543.
