### PR TITLE
Mark JEP-309 as withdrawn

### DIFF
--- a/jep/309/README.adoc
+++ b/jep/309/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Accepted :ok_hand:
+| Withdrawn :hand:
 
 | Type
 | Standards

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -312,7 +312,7 @@
 | link:https://github.com/batmat[Baptiste{nbsp}Mathus]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]
 
-| Accepted{nbsp}:ok_hand:
+| Withdrawn{nbsp}:hand:
 | link:309/README.adoc[JEP-309: Bill of Materials]
 | link:https://github.com/carlossg[Carlos{nbsp}Sanchez], link:https://github.com/oleg-nenashev[Oleg{nbsp}Nenashev]
 | link:https://github.com/rtyler[R.{nbsp}Tyler{nbsp}Croy]


### PR DESCRIPTION
Initially filed as #92 but never fully implemented and will no longer be used anywhere as of https://github.com/jenkinsci/jenkins/pull/7397. See https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/20, https://github.com/jenkinsci/git-plugin/pull/1357, https://github.com/jenkins-infra/pipeline-library/pull/525.