### PR TITLE
[JEP-236] Require Java 11 is complete

### DIFF
--- a/jep/236/README.adoc
+++ b/jep/236/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Accepted :ok_hand:
+| Final :lock:
 
 | Type
 | Process

--- a/jep/236/README.adoc
+++ b/jep/236/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 // Use the script `set-jep-status <jep-number> <status>` to update the status.
 | Status
-| Draft :speech_balloon:
+| Accepted :ok_hand:
 
 | Type
 | Process
@@ -57,8 +57,8 @@ a|
 //
 //
 // Uncomment when this JEP status is set to Accepted, Rejected or Withdrawn.
-//| Resolution
-//| :bulb: Link to relevant post in the jenkinsci-dev@ mailing list archives :bulb:
+| Resolution
+| :bulb: link:https://www.jenkins.io/blog/2022/06/28/require-java-11/#conclusion[Java 11 required for core (blog post)], link:https://www.jenkins.io/blog/2022/12/14/require-java-11/[Java 11 required for plugin development (blog post)], link:https://www.jenkins.io/doc/upgrade-guide/2.361/#jenkins-requires-java-11-or-newer:[2.361.1 upgrade guide], link:https://www.jenkins.io/changelog-stable/#v2.361.1[2.361.1 changelog], and link:https://www.jenkins.io/changelog-old/#v2.357[2.357 changelog] :bulb:
 
 |===
 

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -262,7 +262,7 @@
 | link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
 | TBD
 
-| Draft{nbsp}:speech_balloon:
+| Accepted{nbsp}:ok_hand:
 | link:236/README.adoc[JEP-236: Require Java 11 or newer]
 | link:https://github.com/MarkEWaite[Mark{nbsp}Waite]
 | TBD

--- a/jep/README.adoc
+++ b/jep/README.adoc
@@ -262,7 +262,7 @@
 | link:https://github.com/daniel-beck[Daniel{nbsp}Beck]
 | TBD
 
-| Accepted{nbsp}:ok_hand:
+| Final{nbsp}:lock:
 | link:236/README.adoc[JEP-236: Require Java 11 or newer]
 | link:https://github.com/MarkEWaite[Mark{nbsp}Waite]
 | TBD


### PR DESCRIPTION
## [JEP-236](https://github.com/jenkinsci/jep/blob/master/jep/236/README.adoc) Require Java 11 is complete

Goals of the JEP have been achieved as shown by the links included in the resolution section. Those links include:

* https://www.jenkins.io/blog/2022/06/28/require-java-11/ - Java 11 required for core (blog post)
* https://www.jenkins.io/blog/2022/12/14/require-java-11/ - Java 11 required for plugin development (blog post
* https://www.jenkins.io/doc/upgrade-guide/2.361/ - 2.361.1 upgrade guide
* https://www.jenkins.io/changelog-stable/#v2.361.1 - 2.361.1 changelog
* https://www.jenkins.io/changelog-old/#v2.357 - 2.357 changelog

Marking this JEP as `Accepted` per the definition in:

* https://github.com/jenkinsci/jep/blob/master/jep/1/README.adoc#accepted

Marking this JEP as `Final` per the definition in:

* https://github.com/jenkinsci/jep/blob/master/jep/1/README.adoc#finalizing-a-jep

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
