### PR TITLE
Add Tim Jacomb and Mark Waite to JEP editor list

### DIFF
--- a/jep/1/README.adoc
+++ b/jep/1/README.adoc
@@ -136,6 +136,8 @@ and editorial aspects of the JEP workflow (e.g. assigning JEP numbers and
 changing their status). See <<editor-responsibilities, JEP Editor Responsibilities & Workflow>> for
 details. The current editors are:
 
+* link:https://github.com/timja[Tim Jacomb]
+* link:https://github.com/markewaite[Mark Waite]
 * link:https://github.com/rtyler[R. Tyler Croy]
 * link:https://github.com/oleg-nenashev[Oleg Nenashev]
 * link:https://github.com/bitwiseman[Liam Newman]


### PR DESCRIPTION
## Add Tim Jacomb and Mark Waite to JEP editor list

https://github.com/orgs/jenkinsci/teams/jep-editors is not visible to the general users of the repository. This commit copies the current list into the document.

### Testing done

Reviewed change for consistent use of asciidoc markup

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
