### PR TITLE
Improve template

### DIFF
--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -94,19 +94,6 @@ Give a short (200 word) description of the technical issue addressed.
 * Do not talk about history or why this needs to be done. Instead, add the history to the Motivation section.
 ====
 
-== Specification
-
-[TIP]
-====
-Provide a detailed specification of what is being proposed.
-Be as technical and detailed as needed to allow new or existing Jenkins developers
-to reasonably understand the scope/impact of an implementation.
-
-* Use present tense - describe what the proposal "does" (as if it were already done), not what it will do.
-* Do not discuss alternative designs that were rejected - those belong in the Reasoning section.
-* Avoid in-depth discussion or justification of design choices - that belongs in the Reasoning section.
-====
-
 == Motivation
 
 [TIP]
@@ -114,6 +101,9 @@ to reasonably understand the scope/impact of an implementation.
 Explain why the existing code base or process is inadequate to address the problem that the JEP solves.
 This section may also contain any historical context such as how things were done before this proposal.
 
+* Provide a clear description of the high-level problem you are trying to solve.
+* The problem statement should be written in terms of a specific symptom that affects users, contributors, or the project as a whole.
+* The problem statement should not be written in terms of the solution.
 * Do not discuss design choices or alternative designs that were rejected - those belong in the Reasoning section.
 ====
 
@@ -126,7 +116,24 @@ Describe alternate designs that were considered and related work. For example, h
 Provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
 
 * Use sub-headings to organize this section for ease of readability.
+* Provide a clear description of the cause of the problem.
+* Provide a clear description of the high-level solution you have chosen and how it addresses the cause of the problem.
+* If there were other possible solutions that you considered and rejected, mention those along with the corresponding reasoning.
+* Do not describe implementation details; these should go into the Specification section instead.
 * Do not talk about history or why this needs to be done - that is part of Motivation section.
+====
+
+== Specification
+
+[TIP]
+====
+Provide a detailed specification of what is being proposed.
+Be as technical and detailed as needed to allow new or existing Jenkins developers
+to reasonably understand the scope/impact of an implementation.
+
+* Use present tense - describe what the proposal "does" (as if it were already done), not what it will do.
+* Do not discuss alternative designs that were rejected - those belong in the Reasoning section.
+* Avoid in-depth discussion or justification of design choices - that belongs in the Reasoning section.
 ====
 
 == Backwards Compatibility
@@ -175,9 +182,9 @@ There are no new infrastructure requirements related to this proposal.
 ====
 If the JEP involves any kind of behavioral change to code
 (whether in a Jenkins product or backend infrastructure),
-give a summary of how its correctness (and, if applicable, compatibility, security, etc.) can be tested.
+give a summary of how its correctness (and, if applicable, compatibility, security, etc.) will be tested.
 
-In the preferred case that automated tests can be developed to cover all significant changes, simply give a short summary of the nature of these tests.
+In the preferred case that automated tests will be developed to cover all significant changes, simply give a short summary of the nature of these tests.
 
 If some or all of the changes will require human interaction to verify them, explain why automated tests are considered impractical.
 Then, summarize what kinds of test cases might be required: user scenarios with action steps and expected outcomes.


### PR DESCRIPTION
Fixes several issues I have had with the template for a long time:

- Move the **Specification** section to after the **Reasoning** section. The current order has always seemed backwards to me. The **Specification** section essentially covers the implementation details of the solution. How is this to be understood by the reader if that reader does not first understand the problem and its high-level solution, which are covered in the **Motivation** and **Reasoning** sections? By way of analogy, when writing a mathematical proof, the proof *ends* with the thing you're trying to prove; it doesn't start with it. A mathematical proof starts with definitions, then proceeds to propositions, lemmas, corollaries, and ultimately the explanation of why a statement is true (the proof). This PR simply applies the same logical structure to this document.
- Add clarity to the **Motivation** section based on personal experience. One of the most common mistakes people make in this part of the design process is to write the problem in terms of the solution, so explicitly call out this trap in the hints.
- Add clarity to the **Reasoning** section based on personal experience. One of the most common mistakes people make in this part of the design process is to get bogged down in implementation details or not describing other possible designs, so explicitly call out these traps in the hints.
- Add clarity to the **Testing** section to reflect that testing not just *can* be done but *will* be done. We do not accept untested changes.

### Testing done

Read the new text and it makes sense to me. I have been using these ideas for years in other roles and communities.