### PR TITLE
Add a work estimate section to the template

### DIFF
--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -203,6 +203,25 @@ but must be completed before any JEP is given
 JEPs which will not include code changes may omit this section.
 ====
 
+== Work Estimates
+
+[TIP]
+====
+Provide a clear description of the high-level tasks needed to productize the prototype implementation.
+Ideally these tasks would be turned into work items in an issue tracking system (ITS) like Jira or GitHub Issues.
+As a general rule, it should be possible to complete each task within 1-3 days;
+if a task takes a week or longer, it has not been broken down with enough granularity.
+If these tasks are not obvious, then the prototype is not complete enough.
+Also describe the general roles needed to perform these tasks.
+For example, is the task well-suited to a new contributor,
+or does the task require advanced experience in the Jenkins project that demands a seasoned expert?
+Perhaps the task is well-suited to contributors with an affinity for e.g. frontend development, security, or DevOps.
+Finally, describe the nature of the work in relation to time:
+can these tasks be picked up in parallel by any interested volunteers,
+or do they need to be done in some specific order?
+Do any tasks depend on other tasks in a way that would serialize the implementation of the project?
+====
+
 == References
 
 [TIP]

--- a/jep-template/0000/README.adoc
+++ b/jep-template/0000/README.adoc
@@ -264,6 +264,8 @@ Finally, describe the nature of the work in relation to time:
 can these tasks be picked up in parallel by any interested volunteers,
 or do they need to be done in some specific order?
 Do any tasks depend on other tasks in a way that would serialize the implementation of the project?
+
+JEPs that do not include a prototype implementation may omit this section.
 ====
 
 == References


### PR DESCRIPTION
The Jenkins project does not have dedicated project managers, so architects ought to consider the project management implications of their proposals. My personal experience has been that considering these implications at the time of project design can significantly improve the resulting design by identifying task dependency bottlenecks (and forcing the author to think about if and how they can be resolved) as well as staffing requirements (and forcing the author to revise the design if it is impractical within the realities of staffing constraints). Most importantly, the act of breaking down a prototype into the tasks needed to productize it serves as a forcing function to ensure that the prototype is complete enough to serve its purpose of informing a design. If a prototype is so preliminary that one cannot clearly envision the tasks needed to complete it, then that is an indication that the prototype has failed to explore all the relevant issues in enough depth and that the design is likely to contain gaps and/or errors in judgment.

### Testing done

I have been using these ideas for years in other roles and communities.