### PR TITLE
[JEP-4] Update link to Kubernetes SIG Governance

### DIFF
--- a/jep/4/README.adoc
+++ b/jep/4/README.adoc
@@ -75,7 +75,7 @@ help new contributors join areas of effort which align with their interests.
 == Specification
 
 Much of this specification is modeled after the Kubernetes project's "SIG"
-model. footnoteref:[sig-governance, https://github.com/kubernetes/community/blob/master/sig-governance.md]
+model. footnoteref:[sig-governance, https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md]
 
 
 In order to standardize Special Interest Group efforts, create maximum


### PR DESCRIPTION
This PR updates the Kubernetes SIG Governance link from https://github.com/kubernetes/community/blob/master/sig-governance.md (not found) to https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md